### PR TITLE
Added uppercase hex chars to the AddressChecksum calculation - 

### DIFF
--- a/Assets/SequenceSDK/SequenceSharp/Scripts/SequenceEthereumLibrary/ABI/SequenceCoder.cs
+++ b/Assets/SequenceSDK/SequenceSharp/Scripts/SequenceEthereumLibrary/ABI/SequenceCoder.cs
@@ -34,7 +34,7 @@ namespace Sequence.ABI
                     {
                         checksumAddress += c;
                     }
-                    else if ("abcdef".Contains(c))
+                    else if ("abcdefABCDEF".Contains(c))
                     {
                         int hashedAddressNibble = Convert.ToInt32(hashedAddress[idx].ToString(), 16);
 


### PR DESCRIPTION
without these the function would throw an exception if uppercase hex characters were provided.