### PR TITLE
Fixed makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,5 +48,5 @@ stop:
 	-pkill -F ./testchain/.pid && rm testchain/.pid
 
 test:
-	rm TestResults.xml && cd ./testchain && (yarn start:hardhat & echo $$! > .pid) && cd .. && Unity -runTests -projectPath "$(pwd)" && make stop && mv TestResults*.xml TestResults.xml && \
+	rm TestResults.xml && cd ./testchain && (yarn start:hardhat & echo $$! > .pid) && cd .. && Unity -runTests -projectPath "$(pwd)" ; make stop && mv TestResults*.xml TestResults.xml && \
 	head -n 2 TestResults.xml | grep -Eo 'result="[^"]+"|total="[^"]+"|passed="[^"]+"|failed="[^"]+"|inconclusive="[^"]+"|skipped="[^"]+"|start-time="[^"]+"|end-time="[^"]+"|duration="[^"]+"' | grep -Ev 'clr-version=|engine-version=|asserts=|id=|testcasecount=' | sed -E 's/^[^"]+"([^"]+)"[^"]+"([^"]+)".*/\1: \2/'


### PR DESCRIPTION
such that 'make test' will still run the appropriate cleanup if the test suite fails