### PR TITLE
Fix/cognito sign up

### DIFF
--- a/Assets/Resources/SequenceConfig.asset
+++ b/Assets/Resources/SequenceConfig.asset
@@ -18,9 +18,9 @@ MonoBehaviour:
   FacebookClientId: 
   AppleClientId: 
   Region: us-east-2
-  IdentityPoolId: us-east-2:42c9f39d-c935-4d5c-a845-5c8815c79ee3
+  IdentityPoolId: us-east-2:9747b3b1-c831-4efd-8aee-ac362373ad53
   KMSEncryptionKeyId: arn:aws:kms:us-east-2:170768627592:key/0fd8f803-9cb5-4de5-86e4-41963fb6043d
-  CognitoClientId: 5fl7dg7mvu534o9vfjbc6hj31p
-  WaaSProjectId: 9
+  CognitoClientId: 3fd4tq7gvroie1romfslk2nvv8
+  WaaSProjectId: 124
   WaaSVersion: 1.0.0
   BuilderAPIKey: YfeuczOMRyP7fpr1v7h8SvrCAAAAAAAAA

--- a/Assets/SequenceSDK/Authentication/AWSEmailSignIn.cs
+++ b/Assets/SequenceSDK/Authentication/AWSEmailSignIn.cs
@@ -13,7 +13,7 @@ using Random = UnityEngine.Random;
 
 namespace Sequence.Authentication
 {
-    public class AWSEmailSignIn
+    public class AWSEmailSignIn : IEmailSignIn
     {
         private string _identityPoolId;
         private string _region;
@@ -100,7 +100,6 @@ namespace Sequence.Authentication
             try
             {
                 SignUpResponse response = await client.SignUpAsync(request);
-                int i = 0;
             }
             catch (Exception e)
             {

--- a/Assets/SequenceSDK/Authentication/AWSEmailSignIn.cs
+++ b/Assets/SequenceSDK/Authentication/AWSEmailSignIn.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Threading.Tasks;
 using Amazon;
 using Amazon.CognitoIdentity;
@@ -8,6 +9,7 @@ using Amazon.CognitoIdentityProvider;
 using Amazon.CognitoIdentityProvider.Model;
 using Amazon.Runtime;
 using UnityEngine;
+using Random = UnityEngine.Random;
 
 namespace Sequence.Authentication
 {
@@ -75,6 +77,50 @@ namespace Sequence.Authentication
             {
                 return $"Error establishing AWS session: {e.Message}";
             }
+        }
+
+        public async Task SignUp(string email)
+        {
+            using AmazonCognitoIdentityProviderClient client = new AmazonCognitoIdentityProviderClient(new AnonymousAWSCredentials(), RegionEndpoint.GetBySystemName(_region));
+            SignUpRequest request = new SignUpRequest
+            {
+                ClientId = _cognitoClientId,
+                Username = email,
+                Password = GeneratePassword(),
+                UserAttributes = new List<AttributeType>
+                {
+                    new AttributeType
+                    {
+                        Name = "email",
+                        Value = email
+                    }
+                }
+            };
+
+            try
+            {
+                SignUpResponse response = await client.SignUpAsync(request);
+                int i = 0;
+            }
+            catch (Exception e)
+            {
+                throw new Exception($"Error establishing AWS session: {e.Message}");
+            }
+        }
+
+        private string GeneratePassword()
+        {
+            const string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()_-+=";
+
+            StringBuilder randomChars = new StringBuilder(12);
+            for (int i = 0; i < 12; i++)
+            {
+                randomChars.Append(chars[Random.Range(0, chars.Length)]);
+            }
+
+            string password = $"aB1%{randomChars}";
+
+            return password;
         }
     }
 }

--- a/Assets/SequenceSDK/Authentication/IEmailSignIn.cs
+++ b/Assets/SequenceSDK/Authentication/IEmailSignIn.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+
+namespace Sequence.Authentication
+{
+    public interface IEmailSignIn
+    {
+        public Task<string> SignIn(string email);
+        public Task<string> Login(string challengeSession, string email, string code);
+        public Task SignUp(string email);
+    }
+}

--- a/Assets/SequenceSDK/Authentication/IEmailSignIn.cs.meta
+++ b/Assets/SequenceSDK/Authentication/IEmailSignIn.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 98985ddc09c844e2a5101d8fc3d013e2
+timeCreated: 1705087355

--- a/Assets/SequenceSDK/Authentication/MockEmailSignIn.cs
+++ b/Assets/SequenceSDK/Authentication/MockEmailSignIn.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Sequence.Authentication
+{
+    public class MockEmailSignIn : IEmailSignIn
+    {
+        private int calls = 0;
+        private string _returnValue;
+        private string _secondReturnValue;
+        
+        public MockEmailSignIn(string returnValue, string secondReturnValue = "")
+        {
+            _returnValue = returnValue;
+            _secondReturnValue = secondReturnValue;
+        }
+        
+        public async Task<string> SignIn(string email)
+        {
+            string returnValue = _returnValue;
+            if (calls == 1)
+            {
+                returnValue = _secondReturnValue;
+            }
+            calls++;
+            return returnValue;
+        }
+
+        public async Task<string> Login(string challengeSession, string email, string code)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task SignUp(string email)
+        {
+            return;
+        }
+    }
+}

--- a/Assets/SequenceSDK/Authentication/MockEmailSignIn.cs.meta
+++ b/Assets/SequenceSDK/Authentication/MockEmailSignIn.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 69fdfb9c2a8240a5b05e2716401c9456
+timeCreated: 1705087878

--- a/Assets/SequenceSDK/WaaS/DataTypes/Authentication/WaaSLoginIntent.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/Authentication/WaaSLoginIntent.cs
@@ -14,6 +14,8 @@ namespace Sequence.WaaS.Authentication
             public static string OpenSessionCode = "openSession";
             
             public string code;
+            public uint expires;
+            public uint issued;
             public string session;
             public Proof proof;
 
@@ -24,13 +26,15 @@ namespace Sequence.WaaS.Authentication
             }
         }
 
-        public WaaSLoginIntent(string version, string code, string session, string idToken)
+        public WaaSLoginIntent(string version, string code, string session, string idToken, uint timeBeforeExpiry = 30)
         {
             this.version = version;
             this.packet = new Packet()
             {
                 code = code,
                 session = session,
+                issued = (uint)DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+                expires = (uint)DateTimeOffset.UtcNow.ToUnixTimeSeconds() + timeBeforeExpiry,
                 proof = new Packet.Proof()
                 {
                     idToken = idToken

--- a/Assets/SequenceSDK/WaaS/Tests/InitiateEmailSignInUnitTests.cs
+++ b/Assets/SequenceSDK/WaaS/Tests/InitiateEmailSignInUnitTests.cs
@@ -1,0 +1,67 @@
+using NUnit.Framework;
+using Sequence.Authentication;
+
+namespace Sequence.WaaS.Tests
+{
+    public class InitiateEmailSignInUnitTests
+    {
+        private string _email = "email@domain.com";
+        
+        private WaaSLogin _waasLogin = new WaaSLogin(new AWSConfig("region", "identityPoolId", "kmsEncryptionKeyId", "cognitoClientId"), 1, "version");
+        
+        [Test]
+        public void TestLogin_Success()
+        {
+            _waasLogin.InjectEmailSignIn(new MockEmailSignIn("success"));
+            
+            _waasLogin.OnMFAEmailFailedToSend += (email, error) => Assert.Fail($"Unexpected error: {error}");
+            _waasLogin.OnMFAEmailSent += (email) => Assert.Pass();
+            
+            _waasLogin.Login(_email);
+        }
+
+        [Test]
+        public void TestLogin_UnknownError()
+        {
+            _waasLogin.InjectEmailSignIn(new MockEmailSignIn(""));
+            
+            _waasLogin.OnMFAEmailFailedToSend += (email, error) => Assert.AreEqual("Unknown error establishing AWS session", error);
+            _waasLogin.OnMFAEmailSent += (email) => Assert.Fail($"Unexpected success");
+            
+            _waasLogin.Login(_email);
+        }
+
+        [Test]
+        public void TestLogin_SignUpAndRetrySuccess()
+        {
+            _waasLogin.InjectEmailSignIn(new MockEmailSignIn("user not found", "success"));
+            
+            _waasLogin.OnMFAEmailFailedToSend += (email, error) => Assert.Fail($"Unexpected error: {error}");
+            _waasLogin.OnMFAEmailSent += (email) => Assert.Pass();
+            
+            _waasLogin.Login(_email);
+        }
+        
+        [Test]
+        public void TestLogin_SignUpAndRetryFail()
+        {
+            _waasLogin.InjectEmailSignIn(new MockEmailSignIn("user not found", "user not found"));
+            
+            _waasLogin.OnMFAEmailFailedToSend += (email, error) => Assert.AreEqual("user not found", error);
+            _waasLogin.OnMFAEmailSent += (email) => Assert.Fail($"Unexpected success");
+            
+            _waasLogin.Login(_email);
+        }
+
+        [Test]
+        public void TestLogin_UnexpectedError()
+        {
+            _waasLogin.InjectEmailSignIn(new MockEmailSignIn("Error: something happened"));
+            
+            _waasLogin.OnMFAEmailFailedToSend += (email, error) => Assert.AreEqual("Error: something happened", error);
+            _waasLogin.OnMFAEmailSent += (email) => Assert.Fail($"Unexpected success");
+            
+            _waasLogin.Login(_email);
+        }
+    }
+}

--- a/Assets/SequenceSDK/WaaS/Tests/InitiateEmailSignInUnitTests.cs.meta
+++ b/Assets/SequenceSDK/WaaS/Tests/InitiateEmailSignInUnitTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 49304906a0fa4831a49a431624ca63e0
+timeCreated: 1705087831

--- a/Assets/SequenceSDK/WaaS/WaaSLogin.cs
+++ b/Assets/SequenceSDK/WaaS/WaaSLogin.cs
@@ -14,7 +14,7 @@ namespace Sequence.WaaS
 {
     public class WaaSLogin : ILogin 
     {
-        public const string WaaSWithAuthUrl = "https://d14tu8valot5m0.cloudfront.net/rpc/WaasAuthenticator";
+        public const string WaaSWithAuthUrl = "https://d3jwb7a1rcpkmp.cloudfront.net/rpc/WaasAuthenticator";
         public const string WaaSLoginMethod = "WaaSLoginMethod";
 
         private AWSConfig _awsConfig;


### PR DESCRIPTION
If we fail to send MFA email the first time when trying to sign in with AWS, then the tenant hasn't been configured for email sign in yet and we need to call the sign up method. Then after signing up, we retry the login one time.

See step 3 here https://hackmd.io/@taylanpince/HyAP8JTNa#Passwordless-Cognito-sign-in