### PR TITLE
Clean up appearance of InfoPanel

### DIFF
--- a/Assets/SequenceExamples/Prefabs/InfoPanel.prefab
+++ b/Assets/SequenceExamples/Prefabs/InfoPanel.prefab
@@ -305,7 +305,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 6.6679077}
-  m_SizeDelta: {x: 0, y: -113.3358}
+  m_SizeDelta: {x: -20, y: -113.3358}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6466563803935130064
 CanvasRenderer:
@@ -368,14 +368,14 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 16.3
+  m_fontSize: 16
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
   m_fontSizeMin: 12
-  m_fontSizeMax: 32
+  m_fontSizeMax: 24
   m_fontStyle: 0
-  m_HorizontalAlignment: 2
+  m_HorizontalAlignment: 8
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
@@ -571,7 +571,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8067163605015323916}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0

--- a/Assets/SequenceExamples/Prefabs/LoginPanel.prefab
+++ b/Assets/SequenceExamples/Prefabs/LoginPanel.prefab
@@ -5774,6 +5774,7 @@ MonoBehaviour:
   _animation: 0
   NotifyUserIfTheyAreLoggingInWithADifferentAccountFromLastTime: 1
   _errorText: {fileID: 3911810627816165819}
+  _infoPopupPanelPrefab: {fileID: 8067163605015323916, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
 --- !u!114 &702636062
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/SequenceExamples/Scenes/Demo.unity
+++ b/Assets/SequenceExamples/Scenes/Demo.unity
@@ -1010,118 +1010,115 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 171231629}
     m_Modifications:
-    - target: {fileID: 6466563803935130070, guid: a5a68ec1b8c3c430694abc1729fc5369,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 6.6679077
-      objectReference: {fileID: 0}
-    - target: {fileID: 8067163605015323916, guid: a5a68ec1b8c3c430694abc1729fc5369,
-        type: 3}
-      propertyPath: m_Name
-      value: InfoPanel
-      objectReference: {fileID: 0}
-    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369,
-        type: 3}
+    - target: {fileID: 6466563803935130070, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 300
+      value: -20
       objectReference: {fileID: 0}
-    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 350
-      objectReference: {fileID: 0}
-    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369,
-        type: 3}
+    - target: {fileID: 6466563803935130070, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369,
-        type: 3}
+    - target: {fileID: 6466563803935130070, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 6.6679077
+      objectReference: {fileID: 0}
+    - target: {fileID: 6466563803935130071, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
+      propertyPath: m_fontSize
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 6466563803935130071, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
+      propertyPath: m_fontSizeMax
+      value: 24
+      objectReference: {fileID: 0}
+    - target: {fileID: 6466563803935130071, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
+      propertyPath: m_HorizontalAlignment
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067163605015323916, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
+      propertyPath: m_Name
+      value: InfoPanel
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 300
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 350
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369,
-        type: 3}
+    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369,
-        type: 3}
+    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369,
-        type: 3}
+    - target: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
@@ -1129,8 +1126,7 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
 --- !u!224 &309099120 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 8067163605015323919, guid: a5a68ec1b8c3c430694abc1729fc5369, type: 3}
   m_PrefabInstance: {fileID: 309099119}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &414756634
@@ -1538,8 +1534,7 @@ CanvasRenderer:
   m_CullTransparentMesh: 1
 --- !u!224 &595273815 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
   m_PrefabInstance: {fileID: 2980900696856038333}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &595488887
@@ -2001,7 +1996,7 @@ RectTransform:
   - {fileID: 1018841953}
   - {fileID: 2069053114}
   m_Father: {fileID: 171231629}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -2978,413 +2973,331 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 171231629}
     m_Modifications:
-    - target: {fileID: 535682483669334776, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 535682483669334776, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_SizeDelta.x
       value: 23
       objectReference: {fileID: 0}
-    - target: {fileID: 535682483669334776, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 535682483669334776, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_SizeDelta.y
       value: 29
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626490335500, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626490335500, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_Name
       value: LoginPanel
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchorMin.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_SizeDelta.x
       value: 300
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_SizeDelta.y
       value: 350
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626612855163, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626612855163, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626612855163, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626612855163, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626612855163, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626612855163, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626612855163, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626612855163, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626612855163, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626612855163, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626612855163, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626612855163, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626937435938, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626937435938, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626937435938, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626937435938, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626937435938, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626937435938, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626937435938, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626937435938, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626937435938, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626937435938, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810626937435938, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810626937435938, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627030592632, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627030592632, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627030592632, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627030592632, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627030592632, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627030592632, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627030592632, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627030592632, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627030592632, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627030592632, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627030592632, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627030592632, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627175354181, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627175354181, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627175354181, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627175354181, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627175354181, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627175354181, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627175354181, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627175354181, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627175354181, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627175354181, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627175354181, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627175354181, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627319900539, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627319900539, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627319900539, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627319900539, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627319900539, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627319900539, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627319900539, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627319900539, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627337978483, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627337978483, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627337978483, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627337978483, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627337978483, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627337978483, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627337978483, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627337978483, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627365367141, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627365367141, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627365367141, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627365367141, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627365367141, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627365367141, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627365367141, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627365367141, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627582119963, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627582119963, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627582119963, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627582119963, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627582119963, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627582119963, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627582119963, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627582119963, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627841698846, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627841698846, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627841698846, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627841698846, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627841698846, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627841698846, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627841698846, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627841698846, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627841698846, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627841698846, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810627841698846, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810627841698846, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810628491489748, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810628491489748, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810628491489748, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810628491489748, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810628491489748, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810628491489748, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810628491489748, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810628491489748, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810628491489748, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810628491489748, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3911810628491489748, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 3911810628491489748, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4523793369619621398, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 4523793369619621398, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_SizeDelta.x
       value: 28
       objectReference: {fileID: 0}
-    - target: {fileID: 4523793369619621398, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 4523793369619621398, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_SizeDelta.y
       value: 23
       objectReference: {fileID: 0}
-    - target: {fileID: 8039553140458593208, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 8039553140458593208, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_SizeDelta.x
       value: 24
       objectReference: {fileID: 0}
-    - target: {fileID: 8039553140458593208, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 8039553140458593208, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_SizeDelta.y
       value: 26
       objectReference: {fileID: 0}
-    - target: {fileID: 8817785982066857560, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 8817785982066857560, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_SizeDelta.x
       value: 14
       objectReference: {fileID: 0}
-    - target: {fileID: 8817785982066857560, guid: 4f2f5ce343de8447088bc48817965287,
-        type: 3}
+    - target: {fileID: 8817785982066857560, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
       propertyPath: m_SizeDelta.y
       value: 29
       objectReference: {fileID: 0}
@@ -3392,8 +3305,7 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
 --- !u!224 &1404552076 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 3911810626490335503, guid: 4f2f5ce343de8447088bc48817965287, type: 3}
   m_PrefabInstance: {fileID: 1404552075}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1469989420
@@ -5112,1793 +5024,787 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 171231629}
     m_Modifications:
-    - target: {fileID: 1205280610408878046, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 1205280610408878046, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1205280610408878046, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 1205280610408878046, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1205280610408878046, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 1205280610408878046, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1205280610408878046, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 1205280610408878046, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1687556583891064478, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 1687556583891064478, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1687556583891064478, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 1687556583891064478, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1687556583891064478, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 1687556583891064478, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1687556583891064478, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 1687556583891064478, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1974473085018238379, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 1974473085018238379, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1974473085018238379, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 1974473085018238379, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1974473085018238379, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 1974473085018238379, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1974473085018238379, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 1974473085018238379, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2798441867670105215, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2798441867670105215, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2798441867670105215, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2798441867670105215, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2798441867670105215, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2798441867670105215, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2798441867670105215, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2798441867670105215, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1205280610408878046, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695196224117, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1205280610408878046, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695196224117, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1205280610408878046, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695196224117, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1205280610408878046, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695196224117, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1687556583891064478, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695233699300, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1687556583891064478, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695233699300, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1687556583891064478, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695233699300, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1687556583891064478, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695233699300, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1974473085018238379, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695295444189, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1974473085018238379, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695295444189, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1974473085018238379, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695295444189, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1974473085018238379, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695295444189, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2798441867670105215, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695379668971, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2798441867670105215, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695379668971, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2798441867670105215, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2798441867670105215, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695196224117, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695196224117, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695196224117, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 150
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695196224117, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -290
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695233699300, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695233699300, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695233699300, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 150
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695233699300, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -50
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695295444189, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695295444189, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695295444189, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695295444189, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695295444189, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695295444189, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695295444189, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695295444189, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1205280610408878046, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1205280610408878046, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1205280610408878046, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1205280610408878046, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1687556583891064478, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1687556583891064478, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1687556583891064478, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1687556583891064478, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1974473085018238379, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1974473085018238379, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1974473085018238379, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1974473085018238379, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2798441867670105215, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2798441867670105215, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2798441867670105215, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2798441867670105215, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695295444189, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695295444189, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695295444189, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695295444189, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695379668971, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695379668971, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695379668971, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695379668971, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695379668971, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695379668971, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695379668971, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695379668971, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695523446808, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695523446808, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695523446808, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 130
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695523446808, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -15
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695558038979, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695558038979, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695558038979, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 150
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695558038979, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -185
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695677583050, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695523446808, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695677583050, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695523446808, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695677583050, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695523446808, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695677583050, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695523446808, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695677583050, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695558038979, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695677583050, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695558038979, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695677583050, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695558038979, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695677583050, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695558038979, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695677583050, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695677583050, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695677583050, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695677583050, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695677583050, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695677583050, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695677583050, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695677583050, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695817914343, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695817914343, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695817914343, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695817914343, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695817914343, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695817914343, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695817914343, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695857846706, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695857846706, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695857846706, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 150
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695857846706, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -75
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695876322122, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695876322122, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695876322122, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 150
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695876322122, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -385
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695890846396, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695857846706, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695890846396, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695857846706, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695890846396, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695857846706, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695890846396, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695857846706, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695890846396, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695876322122, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695890846396, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695876322122, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695890846396, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695876322122, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695890846396, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695876322122, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695817914343, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695890846396, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695890846396, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695890846396, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695890846396, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695890846396, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695890846396, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695890846396, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695890846396, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695939724626, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695939724626, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695939724626, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695939724626, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695939724626, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695939724626, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900695939724626, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695942656418, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695942656418, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695942656418, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 150
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695942656418, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -340
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696050489946, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696050489946, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696050489946, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 60
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696050489946, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -15
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900695939724626, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696067011588, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695942656418, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696067011588, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695942656418, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696067011588, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695942656418, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696067011588, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900695942656418, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696124006223, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696050489946, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696124006223, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696050489946, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696124006223, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696050489946, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696124006223, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696050489946, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696124006223, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696067011588, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696124006223, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696067011588, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696124006223, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696067011588, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696124006223, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696067011588, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696148897666, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696148897666, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696148897666, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 68
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696148897666, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -15
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696124006223, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696124006223, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696124006223, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696124006223, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696124006223, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696124006223, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696124006223, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696124006223, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696167876478, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696148897666, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696167876478, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696148897666, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696167876478, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696148897666, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696167876478, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696148897666, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696194897349, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696167876478, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980900696167876478, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980900696167876478, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980900696167876478, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980900696194897349, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696194897349, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696194897349, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696194897349, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696194897349, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696194897349, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696194897349, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_RootOrder
       value: 3
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_SizeDelta.x
       value: 300
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_SizeDelta.y
       value: 350
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696299840490, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696299840491, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696299840491, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_Name
       value: WalletPanel
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696362007278, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696362007278, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696362007278, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696362007278, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696430991612, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696430991612, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696430991612, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696430991612, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696299840491, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696299840491, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696362007278, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696362007278, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696362007278, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696362007278, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696362007278, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696362007278, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696362007278, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696362007278, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696430991612, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696430991612, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696430991612, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696430991612, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696430991612, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696430991612, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696430991612, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696430991612, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696445274699, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696445274699, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696445274699, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 154
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696445274699, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -20
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696520566505, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696520566505, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696520566505, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 150
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696520566505, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -310
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696545480893, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696545480893, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696545480893, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 150
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696545480893, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696671892565, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696445274699, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696671892565, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696445274699, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696671892565, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696445274699, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696671892565, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696445274699, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696671892565, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696520566505, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696671892565, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696520566505, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696671892565, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696520566505, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696671892565, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696520566505, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696299840491, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696362007278, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696545480893, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696362007278, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696545480893, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696362007278, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696545480893, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696362007278, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696545480893, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696430991612, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696671892565, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696430991612, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696671892565, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696430991612, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696671892565, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696430991612, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696671892565, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696671892565, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696834639998, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696671892565, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696834639998, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696671892565, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696671892565, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696834639998, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696834639998, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696834639998, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696834639998, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696834639998, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696834639998, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696834639998, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696834639998, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696981492725, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696981492725, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696981492725, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696981492725, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696981492725, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696981492725, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696981492725, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900696981492725, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900697118336808, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900697118336808, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900697118336808, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900697118336808, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900697118336808, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900697118336808, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900697118336808, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900697118336808, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900696981492725, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696981492725, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696981492725, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696981492725, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900697118336808, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900697118336808, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900697118336808, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900697118336808, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696981492725, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696981492725, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696981492725, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900696981492725, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900697118336808, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900697118336808, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900697118336808, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900697118336808, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900697128280171, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900697128280171, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900697128280171, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900697128280171, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900697128280171, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900697128280171, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900697128280171, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900697128280171, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2980900697159384570, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900697159384570, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900697159384570, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900697159384570, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900697159384570, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900697159384570, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900697159384570, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900697159384570, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900697175016637, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900697175016637, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900697175016637, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900697175016637, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900697175016637, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900697175016637, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 187
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900697175016637, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900697175016637, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -15
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900697197503476, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900697197503476, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900697197503476, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900697197503476, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2980900697197503476, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 2980900697197503476, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3060337371310735457, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 3060337371310735457, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3060337371310735457, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 3060337371310735457, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3060337371310735457, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 3060337371310735457, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3060337371310735457, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 3060337371310735457, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3539061963034780229, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 3539061963034780229, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3539061963034780229, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 3539061963034780229, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3539061963034780229, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 3539061963034780229, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3539061963034780229, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 3539061963034780229, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4693277358180962252, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 4693277358180962252, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4693277358180962252, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 4693277358180962252, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4693277358180962252, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 4693277358180962252, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4693277358180962252, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 4693277358180962252, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5166039746058913982, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 5166039746058913982, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5166039746058913982, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 5166039746058913982, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5166039746058913982, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 5166039746058913982, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5166039746058913982, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 5166039746058913982, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5733732937238783866, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 5733732937238783866, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5733732937238783866, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 5733732937238783866, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5733732937238783866, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 5733732937238783866, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5733732937238783866, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 5733732937238783866, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6559553746371087155, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 6559553746371087155, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6559553746371087155, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 6559553746371087155, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6559553746371087155, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 6559553746371087155, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6559553746371087155, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 6559553746371087155, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3060337371310735457, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 6813335907843917899, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3060337371310735457, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 6813335907843917899, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3060337371310735457, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 6813335907843917899, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3060337371310735457, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 6813335907843917899, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3539061963034780229, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 7557533519693196266, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3539061963034780229, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 7557533519693196266, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3539061963034780229, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 7557533519693196266, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3539061963034780229, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4693277358180962252, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4693277358180962252, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4693277358180962252, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4693277358180962252, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5166039746058913982, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5166039746058913982, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5166039746058913982, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5166039746058913982, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5733732937238783866, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5733732937238783866, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5733732937238783866, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5733732937238783866, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6559553746371087155, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6559553746371087155, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6559553746371087155, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6559553746371087155, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3060337371310735457, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3060337371310735457, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3060337371310735457, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3060337371310735457, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3539061963034780229, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3539061963034780229, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3539061963034780229, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3539061963034780229, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4693277358180962252, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4693277358180962252, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4693277358180962252, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4693277358180962252, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5166039746058913982, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5166039746058913982, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5166039746058913982, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5166039746058913982, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5733732937238783866, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5733732937238783866, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5733732937238783866, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5733732937238783866, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6559553746371087155, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6559553746371087155, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6559553746371087155, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6559553746371087155, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6813335907843917899, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6813335907843917899, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6813335907843917899, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6813335907843917899, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7557533519693196266, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7557533519693196266, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7557533519693196266, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7557533519693196266, guid: 7d8e311766e5c4b8693a216ca3708b52,
-        type: 3}
+    - target: {fileID: 7557533519693196266, guid: 7d8e311766e5c4b8693a216ca3708b52, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}

--- a/Assets/SequenceExamples/Scripts/UI/InfoPopupPanel.cs
+++ b/Assets/SequenceExamples/Scripts/UI/InfoPopupPanel.cs
@@ -21,5 +21,11 @@ namespace Sequence.Demo
             }
             _infoText.text = info;
         }
+
+        public override void Close()
+        {
+            base.Close();
+            Destroy(_gameObject);
+        }
     }
 }

--- a/Assets/SequenceExamples/Scripts/UI/LoginPage.cs
+++ b/Assets/SequenceExamples/Scripts/UI/LoginPage.cs
@@ -13,12 +13,12 @@ namespace Sequence.Demo
     {
         public bool NotifyUserIfTheyAreLoggingInWithADifferentAccountFromLastTime = true;
         [SerializeField] private TextMeshProUGUI _errorText;
+        [SerializeField] private GameObject _infoPopupPanelPrefab;
         
         private TMP_InputField _inputField;
         private LoginMethod _loginMethod;
         private string _loginEmail;
         private LoginButtonHighlighter _loginButtonHighlighter;
-        private InfoPopupPanel _infoPopupPanel;
         private bool _hasShownInfoPopupForDifferentLoginMethod = false;
         internal ILogin LoginHandler { get; private set; }
 
@@ -27,7 +27,6 @@ namespace Sequence.Demo
             base.Awake();
             _inputField = GetComponentInChildren<TMP_InputField>();
             _loginButtonHighlighter = GetComponent<LoginButtonHighlighter>();
-            _infoPopupPanel = FindObjectOfType<InfoPopupPanel>();
         }
 
         private void Start()
@@ -161,9 +160,11 @@ namespace Sequence.Demo
             {
                 message = $"Last time, you logged in with <b>{_loginMethod}</b>: <i>{_loginEmail}</i>. Logging in with a different method or email will use a different account.";
             }
-            if (_infoPopupPanel != null)
+            GameObject infoPopupPanelGameObject = Instantiate(_infoPopupPanelPrefab, transform.parent);
+            InfoPopupPanel infoPopupPanel = infoPopupPanelGameObject.GetComponent<InfoPopupPanel>();
+            if (infoPopupPanel != null)
             {
-                _infoPopupPanel.Open(message);
+                infoPopupPanel.Open(message);
                 _hasShownInfoPopupForDifferentLoginMethod = true;
             }
         }


### PR DESCRIPTION
Utility wise, don't require InfoPanel to exist in the scene; instead, just instantiate it and destroy it when finished.

The panel looked like this before:

https://github.com/0xsequence/sequence-unity/assets/49766546/85029280-68a1-47ac-9eec-05e68a2f0427

and now looks like this:

https://github.com/0xsequence/sequence-unity/assets/49766546/db336895-8508-48bf-b61c-f665e16e0527

The same concept, but a touch cleaner.