### PR TITLE
Log an error and exit early if a user tries to use social sign in on an unsupported platform

### DIFF
--- a/Assets/SequenceSDK/Authentication/OpenIdAuthenticator.cs
+++ b/Assets/SequenceSDK/Authentication/OpenIdAuthenticator.cs
@@ -36,6 +36,13 @@ namespace Sequence.Authentication
 
         public void GoogleSignIn()
         {
+#if UNITY_EDITOR
+            Debug.LogError("Social sign in is not supported in the editor.");
+            return;
+#elif UNITY_WEBGL
+            Debug.LogError("Social sign in is not supported in WebGL.");
+            return;
+#endif
             try
             {
                 string googleSignInUrl = GenerateSignInUrl("https://accounts.google.com/o/oauth2/auth", GoogleClientId, nameof(LoginMethod.Google));
@@ -49,6 +56,13 @@ namespace Sequence.Authentication
         
         public void DiscordSignIn()
         {
+#if UNITY_EDITOR
+            Debug.LogError("Social sign in is not supported in the editor.");
+            return;
+#elif UNITY_WEBGL
+            Debug.LogError("Social sign in is not supported in WebGL.");
+            return;
+#endif
             try
             {
                 string discordSignInUrl =
@@ -63,6 +77,13 @@ namespace Sequence.Authentication
 
         public void FacebookSignIn()
         {
+#if UNITY_EDITOR
+            Debug.LogError("Social sign in is not supported in the editor.");
+            return;
+#elif UNITY_WEBGL
+            Debug.LogError("Social sign in is not supported in WebGL.");
+            return;
+#endif
             try
             {
                 string facebookSignInUrl =
@@ -77,6 +98,13 @@ namespace Sequence.Authentication
         
         public void AppleSignIn()
         {
+#if UNITY_EDITOR
+            Debug.LogError("Social sign in is not supported in the editor.");
+            return;
+#elif UNITY_WEBGL
+            Debug.LogError("Social sign in is not supported in WebGL.");
+            return;
+#endif
             try
             {
                 string appleSignInUrl =


### PR DESCRIPTION
Instead of opening a url and not deep linking back into the app and relying on users to read docs. Instead, we'll just log an error and do nothing