### PR TITLE
Feature/include nonce with OIDC

### DIFF
--- a/Assets/SequenceSDK/Authentication/AWSEmailSignIn.cs
+++ b/Assets/SequenceSDK/Authentication/AWSEmailSignIn.cs
@@ -49,7 +49,7 @@ namespace Sequence.Authentication
             }
         }
 
-        public async Task<string> Login(string challengeSession, string email, string code)
+        public async Task<string> Login(string challengeSession, string email, string code, string sessionWalletAddress = "")
         {
             using AmazonCognitoIdentityProviderClient client = new AmazonCognitoIdentityProviderClient(new AnonymousAWSCredentials(), RegionEndpoint.GetBySystemName(_region));
             RespondToAuthChallengeRequest request = new RespondToAuthChallengeRequest
@@ -63,6 +63,13 @@ namespace Sequence.Authentication
                 ClientId = _cognitoClientId,
                 Session = challengeSession
             };
+            if (!string.IsNullOrWhiteSpace(sessionWalletAddress))
+            {
+                request.ClientMetadata = new Dictionary<string, string>
+                {
+                    { "sessionAddress", sessionWalletAddress }
+                };
+            }
             
             try
             {

--- a/Assets/SequenceSDK/Authentication/IEmailSignIn.cs
+++ b/Assets/SequenceSDK/Authentication/IEmailSignIn.cs
@@ -5,7 +5,7 @@ namespace Sequence.Authentication
     public interface IEmailSignIn
     {
         public Task<string> SignIn(string email);
-        public Task<string> Login(string challengeSession, string email, string code);
+        public Task<string> Login(string challengeSession, string email, string code, string sessionWalletAddress = "");
         public Task SignUp(string email);
     }
 }

--- a/Assets/SequenceSDK/Authentication/MockEmailSignIn.cs
+++ b/Assets/SequenceSDK/Authentication/MockEmailSignIn.cs
@@ -26,7 +26,7 @@ namespace Sequence.Authentication
             return returnValue;
         }
 
-        public async Task<string> Login(string challengeSession, string email, string code)
+        public async Task<string> Login(string challengeSession, string email, string code, string sessionWalletAddress = "")
         {
             throw new NotImplementedException();
         }

--- a/Assets/SequenceSDK/Authentication/OpenIdAuthenticator.cs
+++ b/Assets/SequenceSDK/Authentication/OpenIdAuthenticator.cs
@@ -24,9 +24,10 @@ namespace Sequence.Authentication
         private static readonly string RedirectUrl = "https://dev2-api.sequence.app/oauth/callback";
         
         private string _stateToken = Guid.NewGuid().ToString();
-        private readonly string _nonce = Guid.NewGuid().ToString();
 
-        public OpenIdAuthenticator()
+        private string _sessionAddress;
+
+        public OpenIdAuthenticator(string sessionAddress)
         {
             SequenceConfig config = SequenceConfig.GetConfig();
 
@@ -35,6 +36,8 @@ namespace Sequence.Authentication
             DiscordClientId = config.DiscordClientId;
             FacebookClientId = config.FacebookClientId;
             AppleClientId = config.AppleClientId;
+            
+            _sessionAddress = sessionAddress;
         }
 
         public void GoogleSignIn()
@@ -149,7 +152,7 @@ namespace Sequence.Authentication
             }
             
             string url =
-                $"{baseUrl}?response_type=id_token&client_id={clientId}&redirect_uri={RedirectUrl}&scope=openid+profile+email&state={_urlScheme + "---" + _stateToken + method}&nonce={_nonce}/";
+                $"{baseUrl}?response_type=id_token&client_id={clientId}&redirect_uri={RedirectUrl}&scope=openid+profile+email&state={_urlScheme + "---" + _stateToken + method}&nonce={_sessionAddress}/";
             if (PlayerPrefs.HasKey(LoginEmail))
             {
                 url = url.RemoveTrailingSlash() + $"&login_hint={PlayerPrefs.GetString(LoginEmail)}".AppendTrailingSlashIfNeeded();

--- a/Assets/SequenceSDK/Authentication/Tests/DeepLinkHandlerTests.cs
+++ b/Assets/SequenceSDK/Authentication/Tests/DeepLinkHandlerTests.cs
@@ -10,7 +10,7 @@ namespace Sequence.Authenticator.Tests
         [Test]
         public void TestNoQueryParams()
         {
-            OpenIdAuthenticator authenticator = new OpenIdAuthenticator();
+            OpenIdAuthenticator authenticator = new OpenIdAuthenticator("");
             string url = "https://sequence.app";
             authenticator.HandleDeepLink(url);
             LogAssert.Expect(LogType.Error, "Unexpected deep link: https://sequence.app");
@@ -19,7 +19,7 @@ namespace Sequence.Authenticator.Tests
         [Test]
         public void TestNoStateToken()
         {
-            OpenIdAuthenticator authenticator = new OpenIdAuthenticator();
+            OpenIdAuthenticator authenticator = new OpenIdAuthenticator("");
             string url = "https://sequence.app?code=123456";
             authenticator.HandleDeepLink(url);
             LogAssert.Expect(LogType.Error, "State token missing");
@@ -28,7 +28,7 @@ namespace Sequence.Authenticator.Tests
         [Test]
         public void TestStateTokenMismatch()
         {
-            OpenIdAuthenticator authenticator = new OpenIdAuthenticator();
+            OpenIdAuthenticator authenticator = new OpenIdAuthenticator("");
             string url = "https://sequence.app?code=123456&state=123456";
             authenticator.HandleDeepLink(url);
             LogAssert.Expect(LogType.Error, "State token mismatch");
@@ -37,7 +37,7 @@ namespace Sequence.Authenticator.Tests
         [Test]
         public void TestNoIdToken()
         {
-            OpenIdAuthenticator authenticator = new OpenIdAuthenticator();
+            OpenIdAuthenticator authenticator = new OpenIdAuthenticator("");
             string url = "https://sequence.app?state=123456";
             authenticator.InjectStateTokenForTesting("123456");
             authenticator.HandleDeepLink(url);
@@ -47,7 +47,7 @@ namespace Sequence.Authenticator.Tests
         [Test]
         public void TestValidDeepLink()
         {
-            OpenIdAuthenticator authenticator = new OpenIdAuthenticator();
+            OpenIdAuthenticator authenticator = new OpenIdAuthenticator("");
             string url = "https://sequence.app?state=123456&id_token=654321";
             authenticator.InjectStateTokenForTesting("123456");
             bool eventReceived = false;
@@ -63,7 +63,7 @@ namespace Sequence.Authenticator.Tests
         [Test]
         public void TestValidDeepLink_withTrailingSlash()
         {
-            OpenIdAuthenticator authenticator = new OpenIdAuthenticator();
+            OpenIdAuthenticator authenticator = new OpenIdAuthenticator("");
             string url = "https://sequence.app?state=123456&id_token=654321/";
             authenticator.InjectStateTokenForTesting("123456");
             bool eventReceived = false;

--- a/Assets/package.json
+++ b/Assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz.0xsequence.waas-unity",
-  "version": "2.0.1",
+  "version": "2.1.1",
   "displayName": "Sequence WaaS SDK",
   "description": "A Unity SDK for the Sequence WaaS API",
   "unity": "2021.3",


### PR DESCRIPTION
For security purposes, include session wallet address as a nonce when signing in via OIDC (social sign in). Similarly, include session wallet address as metadata when completing the auth challenge for email sign in.