### PR TITLE
Fix/mute demo game by default

### DIFF
--- a/Assets/Samples~/DemoTowerDefenseGame/UnityTechnologies/TowerDefenseTemplate/Scripts/Core/Data/GameDataStoreBase.cs
+++ b/Assets/Samples~/DemoTowerDefenseGame/UnityTechnologies/TowerDefenseTemplate/Scripts/Core/Data/GameDataStoreBase.cs
@@ -5,7 +5,7 @@
 	/// </summary>
 	public abstract class GameDataStoreBase : IDataStore
 	{
-		public float masterVolume = 1;
+		public float masterVolume = 0;
 
 		public float sfxVolume = 1;
 

--- a/Assets/Samples~/Scripts/SequenceConnector.cs
+++ b/Assets/Samples~/Scripts/SequenceConnector.cs
@@ -3,6 +3,7 @@ using Sequence;
 using Sequence.WaaS;
 using Sequence.WaaS.Authentication;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace Samples.Scripts
 {
@@ -12,7 +13,7 @@ namespace Samples.Scripts
     /// </summary>
     public class SequenceConnector : MonoBehaviour
     {
-        [SerializeField] private Chain _chain;
+        public Chain Chain { get; private set; }
         public static SequenceConnector Instance { get; private set; }
         
         public WaaSWallet Wallet { get; private set; }
@@ -31,7 +32,7 @@ namespace Samples.Scripts
             }
 
             WaaSWallet.OnWaaSWalletCreated += OnWaaSWalletCreated;
-            Indexer = new ChainIndexer(_chain);
+            Indexer = new ChainIndexer(Chain);
         }
 
         private void OnWaaSWalletCreated(WaaSWallet wallet)

--- a/Assets/package.json
+++ b/Assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz.0xsequence.waas-unity",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "displayName": "Sequence WaaS SDK",
   "description": "A Unity SDK for the Sequence WaaS API",
   "unity": "2021.3",


### PR DESCRIPTION
Note: if you've already run the sample game before, you will already have save data for the volume. This is not overwritten. The save data location is calculated in FileSaver.cs and will depend on your system as it is derived from Application.persistentDataPath. You can figure out where this is by using the debugger and delete it. For my machine, it is located at `/Users/quinnpurdy/Library/Application Support/com.HorizonGames.demo-unity-game/save`. Alternatively, you can navigate to the options menu and set the volume to 0, then close the options menu, to save your volume at 0.