### PR TITLE
Rename Editor namespace to Sequence.Editor

### DIFF
--- a/Assets/Samples~/Setup/Editor/CheckUrlScheme.cs
+++ b/Assets/Samples~/Setup/Editor/CheckUrlScheme.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 using UnityEditor.iOS.Xcode;
 #endif
 
-namespace Editor
+namespace Sequence.Editor
 {
     public class CheckUrlScheme
     {

--- a/Assets/package.json
+++ b/Assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz.0xsequence.waas-unity",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "displayName": "Sequence WaaS SDK",
   "description": "A Unity SDK for the Sequence WaaS API",
   "unity": "2021.3",


### PR DESCRIPTION
Without this rename, classes in a project that derive from UnityEditor.Editor will have compile errors if they do not include the UnityEditor prefix as Unity will think they are trying to derive from a namespace and not an extendable class (i.e. UnityEditor.Editor).