### PR TITLE
Fix/transaction return structure

### DIFF
--- a/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/FailedTransactionReturn.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/FailedTransactionReturn.cs
@@ -9,11 +9,11 @@ namespace Sequence.WaaS
     {
         public const string IdentifyingCode = "transactionFailed";
         public string error { get; private set; }
-        public JObject request { get; private set; } // Todo replace with IntentPayload once response structure is updated
+        public IntentPayload request { get; private set; }
         public SimulateResult[] simulations { get; private set; }
 
         [JsonConstructor]
-        public FailedTransactionReturn(string error, JObject request, SimulateResult[] simulations)
+        public FailedTransactionReturn(string error, IntentPayload request, SimulateResult[] simulations)
         {
             this.error = error;
             this.request = request;
@@ -25,9 +25,7 @@ namespace Sequence.WaaS
             this.error = error;
             string requestJson = Newtonsoft.Json.JsonConvert.SerializeObject(request);
             JObject requestJObject = JObject.Parse(requestJson);
-            IntentPayload payload = new IntentPayload("", IntentType.SendTransaction, requestJObject, null);
-            string payloadJson = JsonConvert.SerializeObject(payload);
-            this.request = JObject.Parse(payloadJson);
+            this.request = new IntentPayload("", IntentType.SendTransaction, requestJObject, null);
             this.simulations = null;
         }
     }

--- a/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/SuccessfulTransactionReturn.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/SuccessfulTransactionReturn.cs
@@ -9,12 +9,12 @@ namespace Sequence.WaaS
         public const string IdentifyingCode = "transactionReceipt";
         public string txHash { get; private set; }
         public string metaTxHash { get; private set; }
-        public JObject request { get; private set; }  // Todo replace with IntentPayload once response structure is updated
+        public IntentPayload request { get; private set; }
         public MetaTxnReceipt receipt { get; private set; }
         public JObject nativeReceipt { get; private set; }
         public SimulateResult[] simulations { get; private set; }
 
-        public SuccessfulTransactionReturn(string txHash, string metaTxHash, JObject request, MetaTxnReceipt receipt, JObject nativeReceipt = null, SimulateResult[] simulations = null)
+        public SuccessfulTransactionReturn(string txHash, string metaTxHash, IntentPayload request, MetaTxnReceipt receipt, JObject nativeReceipt = null, SimulateResult[] simulations = null)
         {
             this.txHash = txHash;
             this.metaTxHash = metaTxHash;

--- a/Assets/SequenceSDK/WaaS/WaaSLogin.cs
+++ b/Assets/SequenceSDK/WaaS/WaaSLogin.cs
@@ -107,6 +107,11 @@ namespace Sequence.WaaS
             
             try
             {
+                if (_emailSignIn == null)
+                {
+                    OnMFAEmailFailedToSend?.Invoke(email, "Email sign in not available. Please check for logged warnings; there is most likely a configuration issue.");
+                    return;
+                }
                 _challengeSession = await _emailSignIn.SignIn(email);
                 if (string.IsNullOrEmpty(_challengeSession))
                 {

--- a/Assets/package.json
+++ b/Assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz.0xsequence.waas-unity",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "displayName": "Sequence WaaS SDK",
   "description": "A Unity SDK for the Sequence WaaS API",
   "unity": "2021.3",


### PR DESCRIPTION
Now that the API is returning transaction responses in the correct format, use IntentPayload as opposed to generic JObject in TransactionReturn objects so that we have a clearer picture of the request sent.

Also, return a clearer error when email sign in isn't available, most likely due to a config issue