### PR TITLE
Fix/pull for missing waa s transaction hash

### DIFF
--- a/Assets/SequenceExamples/Scripts/Tests/Utils/MockWaaSWallet.cs
+++ b/Assets/SequenceExamples/Scripts/Tests/Utils/MockWaaSWallet.cs
@@ -60,5 +60,10 @@ namespace SequenceExamples.Scripts.Tests.Utils
         {
             throw new NotImplementedException();
         }
+
+        public Task<SuccessfulTransactionReturn> WaitForTransactionReceipt(SuccessfulTransactionReturn successfulTransactionReturn)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Assets/SequenceExamples/Scripts/Tests/Utils/MockWaaSWallet.cs
+++ b/Assets/SequenceExamples/Scripts/Tests/Utils/MockWaaSWallet.cs
@@ -31,7 +31,7 @@ namespace SequenceExamples.Scripts.Tests.Utils
         public event Action<SuccessfulTransactionReturn> OnSendTransactionComplete;
         public event Action<FailedTransactionReturn> OnSendTransactionFailed;
 
-        public Task<TransactionReturn> SendTransaction(Chain network, Transaction[] transactions, uint timeBeforeExpiry = 30)
+        public Task<TransactionReturn> SendTransaction(Chain network, Transaction[] transactions, bool waitForReceipt = true, uint timeBeforeExpiry = 30)
         {
             throw new NotImplementedException();
         }

--- a/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/IntentDataGetTransactionReceipt.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/IntentDataGetTransactionReceipt.cs
@@ -1,0 +1,27 @@
+using System;
+using Sequence;
+
+namespace SequenceSDK.WaaS
+{
+    [Serializable]
+    public class IntentDataGetTransactionReceipt
+    {
+        public string metaTxHash { get; private set; }
+        public string network { get; private set; }
+        public string wallet { get; private set; }
+
+        public IntentDataGetTransactionReceipt(string metaTxHash, string network, string wallet)
+        {
+            this.metaTxHash = metaTxHash;
+            this.network = network;
+            this.wallet = wallet;
+        }
+
+        public IntentDataGetTransactionReceipt(Address walletAddress, string network, string metaTransactionHash)
+        {
+            this.wallet = walletAddress;
+            this.network = network;
+            this.metaTxHash = metaTransactionHash;
+        }
+    }
+}

--- a/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/IntentDataGetTransactionReceipt.cs.meta
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/IntentDataGetTransactionReceipt.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b4d7947c3c0c4a5e906ebec1fd461592
+timeCreated: 1710456429

--- a/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/IntentPayload.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/IntentPayload.cs
@@ -56,6 +56,7 @@ namespace SequenceSDK.WaaS
             {IntentType.GetSession, "getSession"},
             {IntentType.SignMessage, "signMessage"},
             {IntentType.SendTransaction, "sendTransaction"},
+            {IntentType.GetTransactionReceipt, "getTransactionReceipt"},
         };
     }
 
@@ -69,6 +70,7 @@ namespace SequenceSDK.WaaS
         GetSession,
         SignMessage,
         SendTransaction,
+        GetTransactionReceipt,
         None
     }
 }

--- a/Assets/SequenceSDK/WaaS/HttpClient.cs
+++ b/Assets/SequenceSDK/WaaS/HttpClient.cs
@@ -14,7 +14,7 @@ using UnityEngine.Networking;
 
 namespace Sequence.WaaS
 {
-    public class HttpClient
+    public class HttpClient : IHttpClient
     {
         private readonly string _url;
         private Dictionary<string, string> _defaultHeaders;

--- a/Assets/SequenceSDK/WaaS/IHttpClient.cs
+++ b/Assets/SequenceSDK/WaaS/IHttpClient.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+
+namespace Sequence.WaaS
+{
+    public interface IHttpClient
+    {
+        public Task<T2> SendRequest<T, T2>(string path, T args,
+            [CanBeNull] Dictionary<string, string> headers = null, string overrideUrl = null);
+    }
+}

--- a/Assets/SequenceSDK/WaaS/IHttpClient.cs.meta
+++ b/Assets/SequenceSDK/WaaS/IHttpClient.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5a99f35beac44ac4b4face13dc0dc7a7
+timeCreated: 1710459961

--- a/Assets/SequenceSDK/WaaS/IIntentSender.cs
+++ b/Assets/SequenceSDK/WaaS/IIntentSender.cs
@@ -10,5 +10,6 @@ namespace Sequence.WaaS
         public Task<bool> DropSession(string dropSessionId);
         public Task<T> PostIntent<T>(string payload, string path);
         public Task<WaaSSession[]> ListSessions();
+        public Task<SuccessfulTransactionReturn> GetTransactionReceipt(SuccessfulTransactionReturn response);
     }
 }

--- a/Assets/SequenceSDK/WaaS/IWallet.cs
+++ b/Assets/SequenceSDK/WaaS/IWallet.cs
@@ -23,5 +23,8 @@ namespace Sequence.WaaS
         public Task<bool> DropThisSession();
         public event Action<WaaSSession[]> OnSessionsFound;
         public Task<WaaSSession[]> ListSessions();
+
+        public Task<SuccessfulTransactionReturn> WaitForTransactionReceipt(
+            SuccessfulTransactionReturn successfulTransactionReturn);
     }
 }

--- a/Assets/SequenceSDK/WaaS/IWallet.cs
+++ b/Assets/SequenceSDK/WaaS/IWallet.cs
@@ -14,7 +14,7 @@ namespace Sequence.WaaS
         public Task<IsValidMessageSignatureReturn> IsValidMessageSignature(Chain network, string message, string signature);
         public event Action<SuccessfulTransactionReturn> OnSendTransactionComplete;
         public event Action<FailedTransactionReturn> OnSendTransactionFailed;
-        public Task<TransactionReturn> SendTransaction(Chain network, Transaction[] transactions, uint timeBeforeExpiry = 30);
+        public Task<TransactionReturn> SendTransaction(Chain network, Transaction[] transactions, bool waitForReceipt = true, uint timeBeforeExpiry = 30);
         public event Action<SuccessfulContractDeploymentReturn> OnDeployContractComplete;
         public event Action<FailedContractDeploymentReturn> OnDeployContractFailed;
         public Task<ContractDeploymentReturn> DeployContract(Chain network, string bytecode, string value = "0");

--- a/Assets/SequenceSDK/WaaS/IntentSender.cs
+++ b/Assets/SequenceSDK/WaaS/IntentSender.cs
@@ -18,7 +18,7 @@ namespace Sequence.WaaS
     {
         public string SessionId { get; private set; }
         
-        private HttpClient _httpClient;
+        private IHttpClient _httpClient;
         private Wallet.IWallet _sessionWallet;
         private int _waasProjectId;
         private string _waasVersion;
@@ -29,7 +29,7 @@ namespace Sequence.WaaS
             NullValueHandling = NullValueHandling.Ignore
         };
 
-        public IntentSender(HttpClient httpClient, Wallet.IWallet sessionWallet, string sessionId, int waasProjectId, string waasVersion)
+        public IntentSender(IHttpClient httpClient, Wallet.IWallet sessionWallet, string sessionId, int waasProjectId, string waasVersion)
         {
             _httpClient = httpClient;
             _sessionWallet = sessionWallet;

--- a/Assets/SequenceSDK/WaaS/IntentSender.cs
+++ b/Assets/SequenceSDK/WaaS/IntentSender.cs
@@ -65,18 +65,6 @@ namespace Sequence.WaaS
             if (result.response.code == SuccessfulTransactionReturn.IdentifyingCode)
             {
                 SuccessfulTransactionReturn successfulTransactionReturn = JsonConvert.DeserializeObject<SuccessfulTransactionReturn>(result.response.data.ToString());
-                while (string.IsNullOrWhiteSpace(successfulTransactionReturn.txHash))
-                {
-                    try
-                    {
-                        successfulTransactionReturn = await GetTransactionReceipt(successfulTransactionReturn);
-                    }
-                    catch (Exception e)
-                    {
-                        Debug.LogError("Transaction was successful, but we're unable to obtain the transaction hash. Reason: " + e.Message);
-                        return new IntentResponse<TransactionReturn>(new Response<TransactionReturn>(result.response.code, successfulTransactionReturn));
-                    }
-                }
                 return new IntentResponse<TransactionReturn>(new Response<TransactionReturn>(result.response.code, successfulTransactionReturn));
             }
             else if (result.response.code == FailedTransactionReturn.IdentifyingCode)
@@ -140,7 +128,7 @@ namespace Sequence.WaaS
             return sessions;
         }
         
-        private async Task<SuccessfulTransactionReturn> GetTransactionReceipt(SuccessfulTransactionReturn response)
+        public async Task<SuccessfulTransactionReturn> GetTransactionReceipt(SuccessfulTransactionReturn response)
         {
             JObject requestData = response.request.data;
             if (requestData.TryGetValue("network", out JToken networkJToken))

--- a/Assets/SequenceSDK/WaaS/MockIntentSender.cs
+++ b/Assets/SequenceSDK/WaaS/MockIntentSender.cs
@@ -7,27 +7,34 @@ namespace Sequence.WaaS
 {
     public class MockIntentSender : IIntentSender
     {
-        private object _returnObject;
+        private object[] _returnObjects;
         private Exception _exception;
+        private int _numberOfCalls = 0;
         
-        public MockIntentSender(object returnObject)
+        public MockIntentSender(params object[] returnObjects)
         {
-            _returnObject = returnObject;
+            _returnObjects = returnObjects;
         }
 
         public MockIntentSender(Exception e)
         {
             _exception = e;
         }
+
+        public void InjectException(Exception e)
+        {
+            _exception = e;
+        }
         
         public async Task<T> SendIntent<T, T2>(T2 args, IntentType type = IntentType.None, uint timeBeforeExpiryInSeconds = 30)
         {
-            if (_exception != null)
+            if (_exception != null && !(_numberOfCalls == 0 && _returnObjects != null && _returnObjects.Length > 1))
             {
                 throw _exception;
             }
-            
-            return (T)_returnObject;
+
+            _numberOfCalls++;
+            return (T)_returnObjects[_numberOfCalls - 1];
         }
 
         public Task<bool> DropSession(string dropSessionId)
@@ -43,6 +50,17 @@ namespace Sequence.WaaS
         public Task<WaaSSession[]> ListSessions()
         {
             throw new System.NotImplementedException();
+        }
+
+        public async Task<SuccessfulTransactionReturn> GetTransactionReceipt(SuccessfulTransactionReturn response)
+        {
+            if (_exception != null)
+            {
+                throw _exception;
+            }
+
+            _numberOfCalls++;
+            return (SuccessfulTransactionReturn)_returnObjects[_numberOfCalls - 1];
         }
     }
 }

--- a/Assets/SequenceSDK/WaaS/Tests/IntentSenderTests.cs
+++ b/Assets/SequenceSDK/WaaS/Tests/IntentSenderTests.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using Sequence.Wallet;
+using SequenceSDK.WaaS;
+
+namespace Sequence.WaaS.Tests
+{
+    public class IntentSenderTests
+    {
+        [Test]
+        public async Task SendTransactionIntentTest_FailedTransaction()
+        {
+            IntentSender intentSender = new IntentSender(new MockHttpClientReturnsFailedTransaction(), new EthWallet(), "", 0, "");
+            var result =
+                await intentSender.SendIntent<TransactionReturn, IntentDataSendTransaction>(
+                    new IntentDataSendTransaction("", "", null), IntentType.SendTransaction);
+            if (result is FailedTransactionReturn failedTransactionReturn)
+            {
+                Assert.AreEqual(failedTransactionReturn.error, MockHttpClientReturnsFailedTransaction.error);
+            }
+            else
+            {
+                Assert.Fail($"Did not receive {nameof(FailedTransactionReturn)}");
+            }
+        }
+
+        [Test]
+        public async Task SendTransactionIntentTest_UnknownResponseCode()
+        {
+            IntentSender intentSender = new IntentSender(new MockHttpClientReturnsUnknownCode(), new EthWallet(), "", 0, "");
+            try
+            {
+                var result =
+                    await intentSender.SendIntent<TransactionReturn, IntentDataSendTransaction>(
+                        new IntentDataSendTransaction("", "", null), IntentType.SendTransaction);
+            }
+            catch (Exception e)
+            {
+                Assert.AreEqual(e.Message, $"Unexpected result code: {MockHttpClientReturnsUnknownCode.code}");
+                return;
+            }
+            Assert.Fail("Expected exception but none was thrown");
+        }
+
+        [Test]
+        public async Task SendTransactionIntentTest_SuccessfulTransactionResponse()
+        {
+            IntentSender intentSender = new IntentSender(new MockHttpClientReturnsSuccessfulTransaction(), new EthWallet(), "", 0, "");
+            var result =
+                await intentSender.SendIntent<TransactionReturn, IntentDataSendTransaction>(
+                    new IntentDataSendTransaction("", "", null), IntentType.SendTransaction);
+            if (result is SuccessfulTransactionReturn successfulTransactionReturn)
+            {
+                Assert.AreEqual(successfulTransactionReturn.txHash, MockHttpClientReturnsSuccessfulTransaction.txHash);
+            }
+            else
+            {
+                Assert.Fail($"Did not receive {nameof(SuccessfulTransactionReturn)}");
+            }
+        }
+        
+        // Todo write tests where we get blank txHash back
+        
+
+        private class MockHttpClientReturnsFailedTransaction : IHttpClient
+        {
+            public static string error = "Mock failed transaction";
+            public async Task<T2> SendRequest<T, T2>(string path, T args, Dictionary<string, string> headers = null, string overrideUrl = null)
+            {
+                var response = new IntentResponse<FailedTransactionReturn>(new Response<FailedTransactionReturn>(
+                    FailedTransactionReturn.IdentifyingCode,
+                    new FailedTransactionReturn(error, null, null)));
+                string responseJson = JsonConvert.SerializeObject(response);
+                return JsonConvert.DeserializeObject<T2>(responseJson);
+            }
+        }
+
+        private class MockHttpClientReturnsUnknownCode : IHttpClient
+        {
+            public static string code = "some unrecognized code";
+            public async Task<T2> SendRequest<T, T2>(string path, T args, Dictionary<string, string> headers = null, string overrideUrl = null)
+            {
+                var response = new IntentResponse<FailedTransactionReturn>(new Response<FailedTransactionReturn>(
+                    code,
+                    new FailedTransactionReturn("", null, null)));
+                string responseJson = JsonConvert.SerializeObject(response);
+                return JsonConvert.DeserializeObject<T2>(responseJson);
+            }
+        }
+
+        private class MockHttpClientReturnsSuccessfulTransaction : IHttpClient
+        {
+            public static string txHash = "txhash";
+            public async Task<T2> SendRequest<T, T2>(string path, T args, Dictionary<string, string> headers = null, string overrideUrl = null)
+            {
+                var response = new IntentResponse<SuccessfulTransactionReturn>(new Response<SuccessfulTransactionReturn>(
+                    SuccessfulTransactionReturn.IdentifyingCode,
+                    new SuccessfulTransactionReturn(txHash, "", null, null)));
+                string responseJson = JsonConvert.SerializeObject(response);
+                return JsonConvert.DeserializeObject<T2>(responseJson);
+            }
+        }
+    }
+}

--- a/Assets/SequenceSDK/WaaS/Tests/IntentSenderTests.cs
+++ b/Assets/SequenceSDK/WaaS/Tests/IntentSenderTests.cs
@@ -63,9 +63,6 @@ namespace Sequence.WaaS.Tests
                 Assert.Fail($"Did not receive {nameof(SuccessfulTransactionReturn)}");
             }
         }
-        
-        // Todo write tests where we get blank txHash back
-        
 
         private class MockHttpClientReturnsFailedTransaction : IHttpClient
         {

--- a/Assets/SequenceSDK/WaaS/Tests/IntentSenderTests.cs.meta
+++ b/Assets/SequenceSDK/WaaS/Tests/IntentSenderTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 41c9981cd9a147b79702ae3ea75dee17
+timeCreated: 1710460047

--- a/Assets/SequenceSDK/WaaS/Tests/WaaSToWalletAdapterUnitTests.cs
+++ b/Assets/SequenceSDK/WaaS/Tests/WaaSToWalletAdapterUnitTests.cs
@@ -154,7 +154,7 @@ namespace Sequence.WaaS.Tests
         [Test]
         public async Task TestDeployContractSuccess()
         {
-            SuccessfulTransactionReturn response = new SuccessfulTransactionReturn("", "", null, new MetaTxnReceipt("",
+            SuccessfulTransactionReturn response = new SuccessfulTransactionReturn("0xaeaeaf3bac46dfb11ca18ab318dbc36362b1033a3d637e1b1c49496bab9581a3", "", null, new MetaTxnReceipt("",
                 "", 0, null, new MetaTxnReceipt[]
                 {
                     new MetaTxnReceipt("", "", 0, new MetaTxnReceiptLog[]

--- a/Assets/SequenceSDK/WaaS/WaaSWallet.cs
+++ b/Assets/SequenceSDK/WaaS/WaaSWallet.cs
@@ -208,5 +208,23 @@ namespace Sequence.WaaS
             OnSessionsFound?.Invoke(results);
             return results;
         }
+
+        public async Task<SuccessfulTransactionReturn> WaitForTransactionReceipt(SuccessfulTransactionReturn successfulTransactionReturn)
+        {
+            while (string.IsNullOrWhiteSpace(successfulTransactionReturn.txHash))
+            {
+                try
+                {
+                    successfulTransactionReturn = await _intentSender.GetTransactionReceipt(successfulTransactionReturn);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError("Transaction was successful, but we're unable to obtain the transaction hash. Reason: " + e.Message);
+                    return successfulTransactionReturn;
+                }
+            }
+
+            return successfulTransactionReturn;
+        }
     }
 }

--- a/Assets/SequenceSDK/WaaS/WaaSWallet.cs
+++ b/Assets/SequenceSDK/WaaS/WaaSWallet.cs
@@ -62,14 +62,33 @@ namespace Sequence.WaaS
         public event Action<SuccessfulTransactionReturn> OnSendTransactionComplete;
         public event Action<FailedTransactionReturn> OnSendTransactionFailed;
 
-        public async Task<TransactionReturn> SendTransaction(Chain network, Transaction[] transactions, uint timeBeforeExpiry = 30)
+        public async Task<TransactionReturn> SendTransaction(Chain network, Transaction[] transactions, bool waitForReceipt = true, uint timeBeforeExpiry = 30)
         {
             IntentDataSendTransaction args = new IntentDataSendTransaction(_address, network, transactions);
             try
             {
                 var result = await _intentSender.SendIntent<TransactionReturn, IntentDataSendTransaction>(args, IntentType.SendTransaction, timeBeforeExpiry);
-                if (result is SuccessfulTransactionReturn)
+                if (result is SuccessfulTransactionReturn successfulTransactionReturn)
                 {
+                    if (waitForReceipt)
+                    {
+                        while (string.IsNullOrWhiteSpace(successfulTransactionReturn.txHash))
+                        {
+                            try
+                            {
+                                successfulTransactionReturn = await _intentSender.GetTransactionReceipt(successfulTransactionReturn);
+                            }
+                            catch (Exception e)
+                            {
+                                Debug.LogError("Transaction was successful, but we're unable to obtain the transaction hash. Reason: " + e.Message);
+                                OnSendTransactionComplete?.Invoke(successfulTransactionReturn);
+                                return result;
+                            }
+                        }
+
+                        OnSendTransactionComplete?.Invoke(successfulTransactionReturn);
+                        return successfulTransactionReturn;
+                    }
                     OnSendTransactionComplete?.Invoke((SuccessfulTransactionReturn)result);
                 }
                 else

--- a/Assets/package.json
+++ b/Assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz.0xsequence.waas-unity",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "displayName": "Sequence WaaS SDK",
   "description": "A Unity SDK for the Sequence WaaS API",
   "unity": "2021.3",


### PR DESCRIPTION
WaaS API will now time out when sending transactions when waiting for the transaction hash/transaction receipt. Extend WaaS.IWallet such that users can choose when sending a transaction whether they want to wait for the transaction receipt or just the transaction success confirmation (if a timeout occurs) and then later WaitForTransactionReceipt.