### PR TITLE
Fix/ios serialization issues

### DIFF
--- a/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/DelayedEncode.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/DelayedEncode.cs
@@ -4,10 +4,10 @@ namespace SequenceSDK.WaaS
     public class DelayedEncode : Sequence.WaaS.Transaction
     {
         public const string TypeIdentifier = "delayedEncode";
-        public DelayedEncodeData data { get; private set; }
-        public string to { get; private set; }
-        public string type { get; private set; } = TypeIdentifier;
-        public string value { get; private set; }
+        public DelayedEncodeData data;
+        public string to;
+        public string type = TypeIdentifier;
+        public string value;
         
         public DelayedEncode(string to, string value, DelayedEncodeData data)
         {

--- a/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/Identity.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/Identity.cs
@@ -1,4 +1,5 @@
 using System;
+using Newtonsoft.Json;
 
 namespace SequenceSDK.WaaS
 {
@@ -10,6 +11,7 @@ namespace SequenceSDK.WaaS
         public string sub;
         public string email;
 
+        [JsonConstructor]
         public Identity(string type, string iss, string sub, string email)
         {
             this.type = type;

--- a/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/Identity.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/Identity.cs
@@ -5,10 +5,10 @@ namespace SequenceSDK.WaaS
     [Serializable]
     public class Identity
     {
-        public string type { get; private set; }
-        public string iss { get; private set; }
-        public string sub { get; private set; }
-        public string email { get; private set; }
+        public string type;
+        public string iss;
+        public string sub;
+        public string email;
 
         public Identity(string type, string iss, string sub, string email)
         {

--- a/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/IntentDataCloseSession.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/IntentDataCloseSession.cs
@@ -5,7 +5,7 @@ namespace SequenceSDK.WaaS
     [Serializable]
     public class IntentDataCloseSession
     {
-        public string sessionId { get; private set; }
+        public string sessionId;
 
         public IntentDataCloseSession(string sessionId)
         {

--- a/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/IntentDataFinishValidateSession.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/IntentDataFinishValidateSession.cs
@@ -5,10 +5,10 @@ namespace SequenceSDK.WaaS
     [Serializable]
     public class IntentDataFinishValidateSession
     {
-        public string sessionId { get; private set; }
-        public string wallet { get; private set; }
-        public string salt { get; private set; }
-        public string challenge { get; private set; }
+        public string sessionId;
+        public string wallet;
+        public string salt;
+        public string challenge;
 
         public IntentDataFinishValidateSession(string sessionId, string wallet, string salt, string challenge)
         {

--- a/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/IntentDataGetSession.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/IntentDataGetSession.cs
@@ -5,8 +5,8 @@ namespace SequenceSDK.WaaS
     [Serializable]
     public class IntentDataGetSession
     {
-        public string sessionId { get; private set; }
-        public string wallet { get; private set; }
+        public string sessionId;
+        public string wallet;
 
         public IntentDataGetSession(string sessionId, string walletAddress)
         {

--- a/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/IntentDataGetTransactionReceipt.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/IntentDataGetTransactionReceipt.cs
@@ -6,9 +6,9 @@ namespace SequenceSDK.WaaS
     [Serializable]
     public class IntentDataGetTransactionReceipt
     {
-        public string metaTxHash { get; private set; }
-        public string network { get; private set; }
-        public string wallet { get; private set; }
+        public string metaTxHash;
+        public string network;
+        public string wallet;
 
         public IntentDataGetTransactionReceipt(string metaTxHash, string network, string wallet)
         {

--- a/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/IntentDataListSessions.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/IntentDataListSessions.cs
@@ -5,7 +5,7 @@ namespace SequenceSDK.WaaS
     [Serializable]
     public class IntentDataListSessions
     {
-        public string wallet { get; private set; }
+        public string wallet;
         
         public IntentDataListSessions(string walletAddress)
         {

--- a/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/IntentDataOpenSession.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/IntentDataOpenSession.cs
@@ -8,9 +8,9 @@ namespace SequenceSDK.WaaS
     [Serializable]
     public class IntentDataOpenSession
     {
-        public string email { get; private set; }
-        public string idToken { get; private set; }
-        public string sessionId { get; private set; }
+        public string email;
+        public string idToken;
+        public string sessionId;
 
         public IntentDataOpenSession(Address sessionWallet, string email = null, string idToken = null)
         {

--- a/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/IntentDataSendTransaction.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/IntentDataSendTransaction.cs
@@ -9,10 +9,10 @@ namespace Sequence.WaaS
     [System.Serializable]
     public class IntentDataSendTransaction
     {
-        public string identifier { get; private set; } = Guid.NewGuid().ToString();
-        public string network { get; private set; }
-        public Transaction[] transactions { get; private set; }
-        public string wallet { get; private set; }
+        public string identifier = Guid.NewGuid().ToString();
+        public string network;
+        public Transaction[] transactions;
+        public string wallet;
 
         public static readonly string transactionTypeIdentifier = "type";
 

--- a/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/IntentDataSignMessage.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/IntentDataSignMessage.cs
@@ -7,9 +7,9 @@ namespace Sequence.WaaS
     [Serializable]
     public class IntentDataSignMessage
     {
-        public string message { get; private set; }
-        public string network { get; private set; }
-        public string wallet { get; private set; }
+        public string message;
+        public string network;
+        public string wallet;
 
         public IntentDataSignMessage(string walletAddress, Chain network, string message)
         {

--- a/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/IntentDataValidateSession.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/IntentDataValidateSession.cs
@@ -5,9 +5,9 @@ namespace SequenceSDK.WaaS
     [Serializable]
     public class IntentDataValidateSession
     {
-        public string deviceMetadata { get; private set; }
-        public string sessionId { get; private set; }
-        public string wallet { get; private set; }
+        public string deviceMetadata;
+        public string sessionId;
+        public string wallet;
 
         public IntentDataValidateSession(string sessionId, string wallet, string deviceMetadata)
         {

--- a/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/IntentPayload.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/IntentPayload.cs
@@ -8,12 +8,12 @@ namespace SequenceSDK.WaaS
     [Serializable]
     public class IntentPayload
     {
-        public JObject data { get; private set; }
-        public uint expiresAt { get; private set; }
-        public uint issuedAt { get; private set; }
-        public string name { get; private set; }
-        public Signature[] signatures { get; private set; }
-        public string version { get; private set; }
+        public JObject data;
+        public uint expiresAt;
+        public uint issuedAt;
+        public string name;
+        public Signature[] signatures;
+        public string version;
 
         [JsonConstructor]
         public IntentPayload(string version, string name, uint expiresAt, uint issuedAt, JObject data, Signature[] signatures)

--- a/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/RawTransaction.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/RawTransaction.cs
@@ -10,10 +10,10 @@ namespace Sequence.WaaS
     public class RawTransaction : Sequence.WaaS.Transaction
     {
         public const string TypeIdentifier = "transaction";
-        public string data { get; private set; }
-        public string to { get; private set; }
-        public string type { get; private set; } = TypeIdentifier;
-        public string value { get; private set; }
+        public string data;
+        public string to;
+        public string type = TypeIdentifier;
+        public string value;
 
         public RawTransaction(string to, string value = null, string calldata = null)
         {

--- a/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/RegisterSessionIntent.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/RegisterSessionIntent.cs
@@ -2,8 +2,8 @@ namespace SequenceSDK.WaaS
 {
     public class RegisterSessionIntent
     {
-        public IntentPayload intent { get; private set; }
-        public string friendlyName { get; private set; }
+        public IntentPayload intent;
+        public string friendlyName;
         
         public RegisterSessionIntent(string friendlyName, IntentPayload intent)
         {

--- a/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/SendERC1155.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/SendERC1155.cs
@@ -8,11 +8,11 @@ namespace Sequence.WaaS
     public class SendERC1155 : Sequence.WaaS.Transaction
     {
         public const string TypeIdentifier = "erc1155send";
-        public string data { get; private set; }
-        public string to { get; private set; }
-        public string tokenAddress { get; private set; }
-        public string type { get; private set; } = TypeIdentifier;
-        public SendERC1155Values[] vals { get; private set; }
+        public string data;
+        public string to;
+        public string tokenAddress;
+        public string type = TypeIdentifier;
+        public SendERC1155Values[] vals;
 
         public SendERC1155(string tokenAddress, string to, SendERC1155Values[] sendErc1155Values, string data = null)
         {

--- a/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/SendERC1155Values.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/SendERC1155Values.cs
@@ -5,8 +5,8 @@ namespace SequenceSDK.WaaS
     [Serializable]
     public class SendERC1155Values
     {
-        public string amount { get; private set; }
-        public string id { get; private set; }
+        public string amount;
+        public string id;
 
         public SendERC1155Values(string id, string amount)
         {

--- a/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/SendERC20.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/SendERC20.cs
@@ -6,10 +6,10 @@ namespace SequenceSDK.WaaS
     public class SendERC20 : Sequence.WaaS.Transaction
     {
         public const string TypeIdentifier = "erc20send";
-        public string to { get; private set; }
-        public string tokenAddress { get; private set; }
-        public string type { get; private set; } = TypeIdentifier;
-        public string value { get; private set; }
+        public string to;
+        public string tokenAddress;
+        public string type = TypeIdentifier;
+        public string value;
         
         public SendERC20(string tokenAddress, string to, string value)
         {

--- a/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/SendERC721.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/SendERC721.cs
@@ -8,12 +8,12 @@ namespace SequenceSDK.WaaS
     public class SendERC721 : Sequence.WaaS.Transaction
     {
         public const string TypeIdentifier = "erc721send";
-        public string data { get; private set; }
-        public string id { get; private set; }
-        public bool safe { get; private set; }
-        public string to { get; private set; }
-        public string tokenAddress { get; private set; }
-        public string type { get; private set; } = TypeIdentifier;
+        public string data;
+        public string id;
+        public bool safe;
+        public string to;
+        public string tokenAddress;
+        public string type = TypeIdentifier;
         
         public SendERC721(string tokenAddress, string to, string tokenId, bool safe = true, string data = null)
         {

--- a/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/SendIntentPayload.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/SendIntentPayload.cs
@@ -5,7 +5,7 @@ namespace SequenceSDK.WaaS
     [Serializable]
     public class SendIntentPayload
     {
-        public IntentPayload intent {get; private set;}
+        public IntentPayload intent;
         
         public SendIntentPayload(IntentPayload intent)
         {

--- a/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/Signature.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/Signature.cs
@@ -2,8 +2,8 @@ namespace SequenceSDK.WaaS
 {
     public class Signature
     {
-        public string sessionId { get; private set; }
-        public string signature { get; private set; }
+        public string sessionId;
+        public string signature;
         
         public Signature(string sessionId, string signature)
         {

--- a/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/WaaSSession.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/WaaSSession.cs
@@ -1,4 +1,5 @@
 using System;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using SequenceSDK.WaaS;
 
@@ -17,6 +18,7 @@ namespace Sequence.WaaS
         public DateTime refreshedAt;
         public DateTime expiresAt;
 
+        [JsonConstructor]
         public WaaSSession(string id, string address, string userId, int projectId, Identity identity, string friendlyName, DateTime createdAt, DateTime refreshedAt, DateTime expiresAt)
         {
             this.id = id;

--- a/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/WaaSSession.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ParameterTypes/WaaSSession.cs
@@ -16,6 +16,18 @@ namespace Sequence.WaaS
         public DateTime createdAt;
         public DateTime refreshedAt;
         public DateTime expiresAt;
-            
+
+        public WaaSSession(string id, string address, string userId, int projectId, Identity identity, string friendlyName, DateTime createdAt, DateTime refreshedAt, DateTime expiresAt)
+        {
+            this.id = id;
+            this.address = address;
+            this.userId = userId;
+            this.projectId = projectId;
+            this.identity = identity;
+            this.friendlyName = friendlyName;
+            this.createdAt = createdAt;
+            this.refreshedAt = refreshedAt;
+            this.expiresAt = expiresAt;
+        }
     }
 }

--- a/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/FailedTransactionReturn.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/FailedTransactionReturn.cs
@@ -8,9 +8,9 @@ namespace Sequence.WaaS
     public class FailedTransactionReturn : TransactionReturn
     {
         public const string IdentifyingCode = "transactionFailed";
-        public string error { get; private set; }
-        public IntentPayload request { get; private set; }
-        public SimulateResult[] simulations { get; private set; }
+        public string error;
+        public IntentPayload request;
+        public SimulateResult[] simulations;
 
         [JsonConstructor]
         public FailedTransactionReturn(string error, IntentPayload request, SimulateResult[] simulations)

--- a/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/IntentResponse.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/IntentResponse.cs
@@ -6,7 +6,7 @@ namespace Sequence.WaaS
     [Serializable]
     public class IntentResponse<T>
     {
-        public Response<T> response { get; private set; }
+        public Response<T> response;
 
         public IntentResponse(Response<T> response)
         {
@@ -16,8 +16,8 @@ namespace Sequence.WaaS
     
     public class Response<T>
     {
-        public string code { get; private set; }
-        public T data { get; private set; }
+        public string code;
+        public T data;
         
         public Response(string code, T data)
         {

--- a/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/IntentResponseGetSession.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/IntentResponseGetSession.cs
@@ -5,9 +5,9 @@ namespace SequenceSDK.WaaS
     [Serializable]
     public class IntentResponseGetSession
     {
-        public string sessionId { get; private set; }
-        public string wallet { get; private set; }
-        public bool validated { get; private set; }
+        public string sessionId;
+        public string wallet;
+        public bool validated;
         
         public IntentResponseGetSession(string sessionId, string wallet, bool validated)
         {

--- a/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/IntentResponseSessionOpened.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/IntentResponseSessionOpened.cs
@@ -1,4 +1,5 @@
 using System;
+using Newtonsoft.Json;
 
 namespace Sequence.WaaS
 {
@@ -8,6 +9,7 @@ namespace Sequence.WaaS
         public string sessionId;
         public string wallet;
 
+        [JsonConstructor]
         public IntentResponseSessionOpened(string sessionId, string wallet)
         {
             this.sessionId = sessionId;

--- a/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/IntentResponseValidationFinished.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/IntentResponseValidationFinished.cs
@@ -2,7 +2,7 @@ namespace Sequence.WaaS
 {
     public class IntentResponseValidationFinished
     {
-        public bool isValid { get; private set; }
+        public bool isValid;
         
         public IntentResponseValidationFinished(bool isValid)
         {

--- a/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/IntentResponseValidationRequired.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/IntentResponseValidationRequired.cs
@@ -5,7 +5,7 @@ namespace Sequence.WaaS
     [Serializable]
     public class IntentResponseValidationRequired
     {
-        public string sessionId { get; private set; }
+        public string sessionId;
 
         public IntentResponseValidationRequired(string sessionId)
         {

--- a/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/IntentResponseValidationStarted.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/IntentResponseValidationStarted.cs
@@ -5,7 +5,7 @@ namespace Sequence.WaaS
     [Serializable]
     public class IntentResponseValidationStarted
     {
-        public string salt { get; private set; }
+        public string salt;
         
         public IntentResponseValidationStarted(string salt)
         {

--- a/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/MetaTxnReceipt.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/MetaTxnReceipt.cs
@@ -3,13 +3,13 @@ namespace Sequence.WaaS
     [System.Serializable]
     public class MetaTxnReceipt
     {
-        public string id { get; private set; }
-        public string status { get; private set; }
-        public string revertReason { get; private set; }
-        public int index { get; private set; }
-        public MetaTxnReceiptLog[] logs { get; private set; }
-        public MetaTxnReceipt[] receipts { get; private set; }
-        public string txnReceipt { get; private set; }
+        public string id;
+        public string status;
+        public string revertReason;
+        public int index;
+        public MetaTxnReceiptLog[] logs;
+        public MetaTxnReceipt[] receipts;
+        public string txnReceipt;
 
         public MetaTxnReceipt(string id, string status, int index, MetaTxnReceiptLog[] logs, MetaTxnReceipt[] receipts, string txnReceipt, string revertReason = null)
         {

--- a/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/MetaTxnReceiptLog.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/MetaTxnReceiptLog.cs
@@ -3,15 +3,15 @@ namespace Sequence.WaaS
     [System.Serializable]
     public class MetaTxnReceiptLog
     {
-        public string address { get; private set; }
-        public string[] topics { get; private set; }
-        public string data { get; private set; }
-        public uint blockNumber { get; private set; }
-        public string transactionHash { get; private set; }
-        public uint transactionIndex { get; private set; }
-        public string blockHash { get; private set; }
-        public uint logIndex { get; private set; }
-        public bool removed { get; private set; }
+        public string address;
+        public string[] topics;
+        public string data;
+        public uint blockNumber;
+        public string transactionHash;
+        public uint transactionIndex;
+        public string blockHash;
+        public uint logIndex;
+        public bool removed;
         
         public MetaTxnReceiptLog(string address, string[] topics, string data, uint blockNumber, string transactionHash, uint transactionIndex, string blockHash, uint logIndex, bool removed)
         {

--- a/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/RegisterSessionResponse.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/RegisterSessionResponse.cs
@@ -4,8 +4,8 @@ namespace SequenceSDK.WaaS
 {
     public class RegisterSessionResponse
     {
-        public WaaSSession session { get; private set; }
-        public Response<IntentResponseSessionOpened> response { get; private set; }
+        public WaaSSession session;
+        public Response<IntentResponseSessionOpened> response;
         
         public RegisterSessionResponse(WaaSSession session, Response<IntentResponseSessionOpened> response)
         {

--- a/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/RegisterSessionResponse.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/RegisterSessionResponse.cs
@@ -1,3 +1,4 @@
+using Newtonsoft.Json;
 using Sequence.WaaS;
 
 namespace SequenceSDK.WaaS
@@ -7,6 +8,7 @@ namespace SequenceSDK.WaaS
         public WaaSSession session;
         public Response<IntentResponseSessionOpened> response;
         
+        [JsonConstructor]
         public RegisterSessionResponse(WaaSSession session, Response<IntentResponseSessionOpened> response)
         {
             this.session = session;

--- a/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/SimulateResult.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/SimulateResult.cs
@@ -3,12 +3,12 @@ namespace Sequence.WaaS
     [System.Serializable]
     public class SimulateResult
     {
-        public bool executed { get; private set; }
-        public bool succeeded { get; private set; }
-        public string result { get; private set; }
-        public string reason { get; private set; }
-        public uint gasUsed { get; private set; }
-        public uint gasLimit { get; private set; }
+        public bool executed;
+        public bool succeeded;
+        public string result;
+        public string reason;
+        public uint gasUsed;
+        public uint gasLimit;
 
         public SimulateResult(bool executed, bool succeeded, uint gasUsed, uint gasLimit, string result = null, string reason = null)
         {

--- a/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/SuccessfulTransactionReturn.cs
+++ b/Assets/SequenceSDK/WaaS/DataTypes/ReturnTypes/SuccessfulTransactionReturn.cs
@@ -7,12 +7,12 @@ namespace Sequence.WaaS
     public class SuccessfulTransactionReturn : TransactionReturn
     {
         public const string IdentifyingCode = "transactionReceipt";
-        public string txHash { get; private set; }
-        public string metaTxHash { get; private set; }
-        public IntentPayload request { get; private set; }
-        public MetaTxnReceipt receipt { get; private set; }
-        public JObject nativeReceipt { get; private set; }
-        public SimulateResult[] simulations { get; private set; }
+        public string txHash;
+        public string metaTxHash;
+        public IntentPayload request;
+        public MetaTxnReceipt receipt;
+        public JObject nativeReceipt;
+        public SimulateResult[] simulations;
 
         public SuccessfulTransactionReturn(string txHash, string metaTxHash, IntentPayload request, MetaTxnReceipt receipt, JObject nativeReceipt = null, SimulateResult[] simulations = null)
         {

--- a/Assets/package.json
+++ b/Assets/package.json
@@ -1,12 +1,12 @@
 {
   "name": "xyz.0xsequence.waas-unity",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "displayName": "Sequence WaaS SDK",
   "description": "A Unity SDK for the Sequence WaaS API",
   "unity": "2021.3",
   "keywords": ["Unity", "Package", "wallet", "ethereum", "web3", "sequence", "waas"],
   "dependencies": {
-    "com.unity.nuget.newtonsoft-json" : "3.0.2"
+    "com.unity.nuget.newtonsoft-json" : "3.2.1"
   },
   "author": {
     "name": "0xsequence",


### PR DESCRIPTION
In later 2021 Unity versions as well as all of 2022 and 2023 versions, a bug was introduced into the editor that has caused script behaviours to diverge depending on whether they are loaded into the Packages folder or the Assets folder when targeting the iOS build platform. All that should be different is the mutability of those scripts, not functionality, with scripts in the Packages folder being immutable.

In our case, this lead to Json serialization being broken whenever a property has an access modifier (such as the widely used { get; private set;}). Removing the access modifier seems to resolve the issue on our end.