### PR TITLE
Fix/setup login for federation social

### DIFF
--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/SequenceLogin.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/SequenceLogin.cs
@@ -145,15 +145,25 @@ namespace Sequence.EmbeddedWallet
 
         public void TryToRestoreSession()
         {
-            if (!_storeSessionWallet || _connectedWalletAddress != null)
+            if (!_storeSessionWallet)
             {
                 return;
+            }
+
+            if (_connectedWalletAddress != null)
+            {
+                FailedLoginWithStoredSessionWallet("Cannot restore session when connected wallet address is set");
             }
             TryToLoginWithStoredSessionWallet();
         }
 
         public void GuestLogin()
         {
+            if (_connectedWalletAddress != null)
+            {
+                FederateAccountGuest(_connectedWalletAddress);
+                return;
+            }
             ConnectToWaaSAsGuest();
         }
 
@@ -290,7 +300,14 @@ namespace Sequence.EmbeddedWallet
         public async Task Login(string email, string code)
         {
             _isLoggingIn = true;
-            await _emailConnector.ConnectToWaaSViaEmail(email, code);
+            if (_connectedWalletAddress != null)
+            {
+                await FederateEmail(email, code, _connectedWalletAddress);
+            }
+            else
+            {
+                await _emailConnector.ConnectToWaaSViaEmail(email, code);
+            }
         }
 
         public void GoogleLogin()
@@ -502,7 +519,14 @@ namespace Sequence.EmbeddedWallet
 
         public void PlayFabLogin(string titleId, string sessionTicket, string email)
         {
-            ConnectToWaaSViaPlayFab(titleId, sessionTicket, email);
+            if (_connectedWalletAddress != null)
+            {
+                FederateAccountPlayFab(titleId, sessionTicket, email, _connectedWalletAddress);
+            }
+            else
+            {
+                ConnectToWaaSViaPlayFab(titleId, sessionTicket, email);
+            }
         }
 
         public void ForceCreateAccount()

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/SequenceLogin.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/SequenceLogin.cs
@@ -153,6 +153,7 @@ namespace Sequence.EmbeddedWallet
             if (_connectedWalletAddress != null)
             {
                 FailedLoginWithStoredSessionWallet("Cannot restore session when connected wallet address is set");
+                return;
             }
             TryToLoginWithStoredSessionWallet();
         }

--- a/Packages/Sequence-Unity/package.json
+++ b/Packages/Sequence-Unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz.0xsequence.waas-unity",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "displayName": "Sequence Embedded Wallet SDK",
   "description": "A Unity SDK for the Sequence WaaS API",
   "unity": "2021.3",


### PR DESCRIPTION
SequenceLogin automatically logs the user in to WaaS after social sign in

With this update, you can call SequenceLogin.GetInstanceToFederateAuth(walletAddress) to get the SequenceLogin instance setup such that it will federate auth instead of signing in or you can call SetConnectedWalletAddress(walletAddress) on a SequenceLogin instance to do the same thing