### PR TITLE
Feature/editor secure storage

### DIFF
--- a/Packages/Sequence-Unity/Plugins/MacOS/KeychainAccess.bundle.meta
+++ b/Packages/Sequence-Unity/Plugins/MacOS/KeychainAccess.bundle.meta
@@ -18,7 +18,7 @@ PluginImporter:
       enabled: 0
       settings:
         Exclude Android: 1
-        Exclude Editor: 1
+        Exclude Editor: 0
         Exclude Linux64: 1
         Exclude OSXUniversal: 0
         Exclude WebGL: 1
@@ -39,7 +39,7 @@ PluginImporter:
   - first:
       Editor: Editor
     second:
-      enabled: 0
+      enabled: 1
       settings:
         CPU: AnyCPU
         DefaultValueInitialized: true

--- a/Packages/Sequence-Unity/Plugins/iOS/KeychainAccess.mm.meta
+++ b/Packages/Sequence-Unity/Plugins/iOS/KeychainAccess.mm.meta
@@ -1,3 +1,37 @@
 fileFormatVersion: 2
 guid: a02383ed444549c882faaaba4de8008c
-timeCreated: 1717784885
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      tvOS: tvOS
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/Sequence-Unity/Sequence/SequenceFrontend/Scripts/UI/LoginPanel.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceFrontend/Scripts/UI/LoginPanel.cs
@@ -43,7 +43,7 @@ namespace Sequence.Demo
             
             SequenceWallet.OnFailedToRecoverSession += OnFailedToRecoverSession;
 
-            _storeSessionInfoAndSkipLoginWhenPossible = config.StoreSessionPrivateKeyInSecureStorage;
+            _storeSessionInfoAndSkipLoginWhenPossible = config.StoreSessionKey();
             
             ILogin loginHandler = SequenceLogin.GetInstance();
             SetupLoginHandler(loginHandler);

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Config/SequenceConfig.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Config/SequenceConfig.cs
@@ -34,6 +34,7 @@ namespace Sequence.Config
         [Header("Sequence SDK Configuration")] 
         public string BuilderAPIKey;
         public bool StoreSessionPrivateKeyInSecureStorage = false;
+        public bool EditorStoreSessionPrivateKeyInSecureStorage = false;
         
         private static SequenceConfig _config;
 
@@ -75,6 +76,15 @@ namespace Sequence.Config
             }
 
             return JwtHelper.GetConfigJwt(configKey);
+        }
+
+        public bool StoreSessionKey()
+        {
+#if UNITY_EDITOR
+            return EditorStoreSessionPrivateKeyInSecureStorage;
+#else
+            return StoreSessionPrivateKeyInSecureStorage;
+#endif
         }
     }
 }

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/SequenceLogin.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/SequenceLogin.cs
@@ -267,7 +267,7 @@ namespace Sequence.EmbeddedWallet
         private (EOAWallet, string) AttemptToCreateWalletFromSecureStorage()
         {
             ISecureStorage secureStorage = SecureStorageFactory.CreateSecureStorage();
-            string walletInfo = secureStorage.RetrieveString(_walletKey);
+            string walletInfo = secureStorage.RetrieveString(Application.companyName + "-" + Application.productName + "-" + _walletKey);
             if (string.IsNullOrEmpty(walletInfo))
             {
                 return (null, "");
@@ -575,7 +575,7 @@ namespace Sequence.EmbeddedWallet
             byte[] privateKeyBytes = new byte[32];
             _sessionWallet.privKey.WriteToSpan(privateKeyBytes);
             string privateKey = privateKeyBytes.ByteArrayToHexString();
-            secureStorage.StoreString(_walletKey, privateKey + "-" + waasWalletAddress);
+            secureStorage.StoreString(Application.companyName + "-" + Application.productName + "-" + _walletKey, privateKey + "-" + waasWalletAddress);
         }
 
         public async Task FederateAccount(IntentDataFederateAccount federateAccount, LoginMethod method, string email)

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/SequenceLogin.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/SequenceLogin.cs
@@ -86,7 +86,7 @@ namespace Sequence.EmbeddedWallet
             _automaticallyFederateAccountsWhenPossible = automaticallyFederateAccountsWhenPossible;
             SetConnectedWalletAddress(connectedWalletAddress);
             
-            bool storeSessionWallet = SequenceConfig.GetConfig().StoreSessionPrivateKeyInSecureStorage && SecureStorageFactory.IsSupportedPlatform() && connectedWalletAddress == null;
+            bool storeSessionWallet = SequenceConfig.GetConfig().StoreSessionKey() && SecureStorageFactory.IsSupportedPlatform() && connectedWalletAddress == null;
             if (storeSessionWallet)
             {
                 _storeSessionWallet = true;

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/SessionManager.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/SessionManager.cs
@@ -34,7 +34,7 @@ namespace Sequence.EmbeddedWallet
 
         private void OnApplicationQuit()
         {
-            if (SequenceConfig.GetConfig().StoreSessionPrivateKeyInSecureStorage && SecureStorageFactory.IsSupportedPlatform())
+            if (SequenceConfig.GetConfig().StoreSessionKey() && SecureStorageFactory.IsSupportedPlatform())
             {
                 return;
             }

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Utils/SecureStorage/MacOSKeychainStorage.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Utils/SecureStorage/MacOSKeychainStorage.cs
@@ -8,12 +8,12 @@ namespace Sequence.Utils.SecureStorage
     {
         public MacOSKeychainStorage()
         {
-#if !UNITY_STANDALONE_OSX || UNITY_EDITOR
+#if !UNITY_STANDALONE_OSX && !UNITY_EDITOR_OSX
             throw new System.NotSupportedException("MacOSKeychainStorage is only supported on macOS platform.");
 #endif
         }
 
-#if UNITY_STANDALONE_OSX && !UNITY_EDITOR
+#if UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX
         [DllImport("KeychainAccess")]
         private static extern void SaveKeychainValue(string key, string value);
 

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Utils/SecureStorage/SecureStorageFactory.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Utils/SecureStorage/SecureStorageFactory.cs
@@ -9,7 +9,7 @@ namespace Sequence.Utils.SecureStorage
         {
 #if UNITY_IOS && !UNITY_EDITOR
             return new iOSKeychainStorage();
-#elif UNITY_STANDALONE_OSX && !UNITY_EDITOR
+#elif UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX
             return new MacOSKeychainStorage();
 #elif UNITY_WEBGL && !UNITY_EDITOR
             return new WebSecureStorage();

--- a/Packages/Sequence-Unity/package.json
+++ b/Packages/Sequence-Unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz.0xsequence.waas-unity",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "displayName": "Sequence Embedded Wallet SDK",
   "description": "A Unity SDK for the Sequence WaaS API",
   "unity": "2021.3",


### PR DESCRIPTION
Added secure private key storage for when in editor. This uses our PC storage system (DPAPI) on PC and Mac storage system (Keychain) on Mac. To make it easier for devs to test both flows without affecting builds, we have an additional toggle in SequenceConfig to enable or disable session recovery and private key storage

Additionally, since the Unity Editor is one "application" from the perspective of the storage system, I've added a prefix ($"{company name}-{product name}-") to the key we store the session wallet under so that multiple apps in development can store their session wallet info and recover sessions.

Docs PR: https://github.com/0xsequence/docs/pull/252