### PR TITLE
Feature/iap minter

### DIFF
--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Marketplace.meta
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Marketplace.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9af6b59e220cd40c8b0ab776c5f82a0d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Relayer/MintingRequestProver.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Relayer/MintingRequestProver.cs
@@ -24,7 +24,17 @@ namespace Sequence.Relayer
             _proofSigner = new SequenceWalletProofSigner(wallet, _chain);
         }
 
-        public async Task<MintingRequestProof> GenerateProof(string contractAddress, string tokenId, uint amount)
+        public Task<MintingRequestProof> GenerateProof(string contractAddress, string tokenId, uint amount)
+        {
+            return GenerateProof(new MintRequestPayload()
+            {
+                contractAddress = contractAddress,
+                tokenId = tokenId,
+                amount = amount
+            });
+        }
+
+        public async Task<MintingRequestProof> GenerateProof(MintRequestPayload payload)
         {
             ProofPayload proofPayload = new ProofPayload()
             {
@@ -32,12 +42,7 @@ namespace Sequence.Relayer
                 iat = (uint)DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
                 exp = (uint)DateTimeOffset.UtcNow.ToUnixTimeSeconds() + 300,
                 ogn = "Sequence Unity SDK",
-                payload = new MintRequestPayload()
-                {
-                    contractAddress = contractAddress,
-                    tokenId = tokenId,
-                    amount = amount
-                }
+                payload = payload
             };
             string proof = JsonConvert.SerializeObject(proofPayload);
             string signedProof = await _proofSigner.SignProof(proof);

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Relayer/PermissionedMinter.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Relayer/PermissionedMinter.cs
@@ -16,9 +16,9 @@ namespace Sequence.Relayer
     {
         private string _mintEndpoint;
         
-        private MintingRequestProver _mintingRequestProver;
+        protected MintingRequestProver _mintingRequestProver;
 
-        private Address _contractAddress;
+        protected Address _contractAddress;
         
         public PermissionedMinter(MintingRequestProver mintingRequestProver, string mintEndpoint, string contractAddress)
         {
@@ -30,7 +30,7 @@ namespace Sequence.Relayer
         public event Action<string> OnMintTokenSuccess;
         public event Action<string> OnMintTokenFailed;
 
-        public async Task<string> BuildMintTokenRequestJson(string tokenId, uint amount = 1)
+        public virtual async Task<string> BuildMintTokenRequestJson(string tokenId, uint amount = 1)
         {
             MintingRequestProof requestProof =
                 await _mintingRequestProver.GenerateProof(_contractAddress, tokenId, amount);

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Relayer/PremiumIAPMinter.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Relayer/PremiumIAPMinter.cs
@@ -1,0 +1,7 @@
+namespace Sequence.Relayer
+{
+    public class PremiumMinter
+    {
+        
+    }
+}

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Relayer/PremiumIAPMinter.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Relayer/PremiumIAPMinter.cs
@@ -1,7 +1,44 @@
+using System;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
 namespace Sequence.Relayer
 {
-    public class PremiumMinter
+    public class PremiumIAPMinter : PermissionedMinter
     {
+        private string _iapReceipt;
         
+        public PremiumIAPMinter(MintingRequestProver mintingRequestProver, string mintEndpoint, string contractAddress, string iapReceipt) : base(mintingRequestProver, mintEndpoint, contractAddress)
+        {
+            _iapReceipt = iapReceipt;
+        }
+
+        public override async Task<string> BuildMintTokenRequestJson(string tokenId, uint amount = 1)
+        {
+            MintingRequestProof requestProof =
+                await _mintingRequestProver.GenerateProof(new PremiumIAPMintRequestPayload(_contractAddress, tokenId, amount, _iapReceipt));
+
+            MintTokenRequest mintTokenRequest = new MintTokenRequest(requestProof);
+
+            string mintTokenRequestJson = JsonConvert.SerializeObject(mintTokenRequest);
+            return mintTokenRequestJson;
+        }
+    }
+    
+    [Serializable]
+    public class PremiumIAPMintRequestPayload : MintRequestPayload
+    {
+        public string contractAddress;
+        public string tokenId;
+        public uint amount;
+        public string iapReceipt;
+
+        public PremiumIAPMintRequestPayload(string contractAddress, string tokenId, uint amount, string iapReceipt)
+        {
+            this.contractAddress = contractAddress;
+            this.tokenId = tokenId;
+            this.amount = amount;
+            this.iapReceipt = iapReceipt;
+        }
     }
 }

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Relayer/PremiumIAPMinter.cs.meta
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Relayer/PremiumIAPMinter.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: af5e9647ff284f5285e02e00a17e5e4f
+timeCreated: 1726585693

--- a/Packages/Sequence-Unity/package.json
+++ b/Packages/Sequence-Unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz.0xsequence.waas-unity",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "displayName": "Sequence Embedded Wallet SDK",
   "description": "A Unity SDK for the Sequence WaaS API",
   "unity": "2021.3",


### PR DESCRIPTION
Made the PermissionedMinterTransactionQueuer more flexibility and added in support for IAP-based minting

Sample code:

```
PremiumIAPMinter minter = new PremiumIAPMinter(new MintingRequestProver(Wallet, Chain),
                _mintEndpoint, ContractAddress, iapReceipt);
            _permissionedMinterTransactionQueuer.Enqueue((payload, minter));
```