### PR TITLE
Update supported networks

### DIFF
--- a/Assets/SequenceSDK/Indexer/Tests/ChainIndexerTests.cs
+++ b/Assets/SequenceSDK/Indexer/Tests/ChainIndexerTests.cs
@@ -20,7 +20,7 @@ namespace Sequence.Indexer.Tests
         [TestCaseSource(nameof(chainIdCases))]
         public void TestCreateChainIndexerForChain(Chain chain)
         {
-            if (chain == Chain.None) return;
+            if (ChainIsInactive(chain)) return;
             try
             {
                 ChainIndexer chainIndexer = new ChainIndexer(chain);
@@ -36,7 +36,7 @@ namespace Sequence.Indexer.Tests
         [TestCaseSource(nameof(chainIdCases))]
         public async Task TestPingChain(Chain chain)
         {
-            if (chain == Chain.None) return;
+            if (ChainIsInactive(chain)) return;
             try
             {
                 IIndexer chainIndexer = new ChainIndexer(chain);
@@ -52,7 +52,7 @@ namespace Sequence.Indexer.Tests
         [TestCaseSource(nameof(chainIdCases))]
         public async Task TestVersion(Chain chain)
         {
-            if (chain == Chain.None) return;
+            if (ChainIsInactive(chain)) return;
             try
             {
                 IIndexer indexer = new ChainIndexer(chain);
@@ -68,11 +68,16 @@ namespace Sequence.Indexer.Tests
                 Assert.Fail("Encountered exception when none was expected: " + e.Message);
             }
         }
+
+        private bool ChainIsInactive(Chain chain)
+        {
+            return chain == Chain.None || chain == Chain.AstarZKEvm || chain == Chain.TestnetAstarZKyoto;
+        }
         
         [TestCaseSource(nameof(chainIdCases))]
         public async Task TestRuntimeStatus(Chain chain)
         {
-            if (chain == Chain.None) return;
+            if (ChainIsInactive(chain)) return;
             RuntimeStatus result = null;
             try
             {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Ethereum/Chain.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Ethereum/Chain.cs
@@ -37,6 +37,7 @@ namespace Sequence
         TestnetBorne = 94984,
         TestnetSkaleNebulaGamingHub = 37084624,
         TestnetSoneiumMinato = 1946,
+        TestnetToy = 21000000,
         
         TestnetXaiSepolia = -1, // Xai Sepolia's testnet's chain ID is too large to fit inside an int
         

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Ethereum/Chain.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Ethereum/Chain.cs
@@ -1,4 +1,5 @@
-﻿using System.Numerics;
+﻿using System;
+using System.Numerics;
 
 namespace Sequence
 {
@@ -16,10 +17,13 @@ namespace Sequence
         Gnosis = 100,
         Base = 8453,
         OasysHomeverse = 19011,
+        [Obsolete("Chain is no longer active; use TestnetSoneiumMinato instead")]
         AstarZKEvm = 3776,
         Xai = 660279,
         Blast = 81457,
-        
+        B3 = 8333,
+        APEChain = 33139,
+
         // Testnets
         TestnetSepolia = 11155111,
         TestnetPolygonAmoy = 80002,
@@ -29,6 +33,7 @@ namespace Sequence
         TestnetAvalanche = 43113,
         TestnetOasysHomeverse = 40875,
         TestnetOptimisticSepolia = 11155420,
+        [Obsolete("Chain is no longer active; use TestnetSoneiumMinato instead")]
         TestnetAstarZKyoto = 6038361,
         TestnetXrSepolia = 2730,
         TestnetB3Sepolia = 1993,

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Ethereum/ChainDictionaries.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Ethereum/ChainDictionaries.cs
@@ -20,6 +20,8 @@ namespace Sequence
             { Chain.Xai, "Xai" },
             { Chain.AstarZKEvm, "Astar zkEVM" },
             { Chain.Blast, "Blast" },
+            { Chain.B3, "B3" },
+            { Chain.APEChain, "APE Chain" },
             
             { Chain.TestnetSepolia, "Sepolia" },
             { Chain.TestnetArbitrumSepolia, "Arbitrum Sepolia" },
@@ -57,6 +59,8 @@ namespace Sequence
             { Chain.AstarZKEvm, "ETH" },
             { Chain.Xai, "XAI" },
             { Chain.Blast, "ETH" },
+            { Chain.B3, "ETH" },
+            { Chain.APEChain, "APE" },
 
             { Chain.TestnetSepolia, "ETH" },
             { Chain.TestnetArbitrumSepolia, "AETH" },
@@ -94,6 +98,8 @@ namespace Sequence
             { Chain.AstarZKEvm, "https://astar-zkevm.explorer.startale.com/" },
             { Chain.Xai, "https://explorer.xai-chain.net/" }, 
             { Chain.Blast, "https://blastscan.io/" },
+            { Chain.B3, "https://explorer.b3.fun/" },
+            { Chain.APEChain, "https://apescan.io/" },
 
             { Chain.TestnetSepolia, "https://sepolia.etherscan.io/" },
             { Chain.TestnetArbitrumSepolia, "https://sepolia.arbiscan.io/" },
@@ -112,7 +118,7 @@ namespace Sequence
             { Chain.TestnetBorne, "https://subnets-test.avax.network/bornegfdn" },
             { Chain.TestnetSkaleNebulaGamingHub, "https://green-giddy-denebola.explorer.mainnet.skalenodes.com/" },
             { Chain.TestnetSoneiumMinato, "https://explorer-testnet.soneium.org/" },
-            { Chain.TestnetToy, "" } // Not found
+            { Chain.TestnetToy, "https://toy-chain-testnet.explorer.caldera.xyz/" }
         };
         
         public static Dictionary<Chain, string> ChainIdOf = new Dictionary<Chain, string>()
@@ -133,6 +139,8 @@ namespace Sequence
             { Chain.AstarZKEvm, "3776" },
             { Chain.Xai, "660279" },
             { Chain.Blast, "81457" },
+            { Chain.B3, "8333" },
+            { Chain.APEChain, "33139" },
             
             { Chain.TestnetSepolia, "11155111" },
             { Chain.TestnetPolygonAmoy, "80002" },
@@ -170,6 +178,8 @@ namespace Sequence
             { "3776", Chain.AstarZKEvm },
             { "660279", Chain.Xai },
             { "81457", Chain.Blast },
+            { "8333", Chain.B3 },
+            { "33139", Chain.APEChain },
             
             { "11155111", Chain.TestnetSepolia },
             { "80002", Chain.TestnetPolygonAmoy },
@@ -207,6 +217,8 @@ namespace Sequence
             { Chain.AstarZKEvm, "astar-zkevm" },
             { Chain.Xai, "xai" },
             { Chain.Blast, "blast" },
+            { Chain.B3, "b3" },
+            { Chain.APEChain, "apechain" },
 
             { Chain.TestnetSepolia, "sepolia" },
             { Chain.TestnetArbitrumSepolia, "arbitrum-sepolia" },

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Ethereum/ChainDictionaries.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Ethereum/ChainDictionaries.cs
@@ -37,7 +37,8 @@ namespace Sequence
             { Chain.TestnetBlastSepolia, "Blast Sepolia" },
             { Chain.TestnetBorne, "Borne Testnet" },
             { Chain.TestnetSkaleNebulaGamingHub, "Skale Nebula Gaming Hub Testnet" },
-            { Chain.TestnetSoneiumMinato, "Soneium Minato Testnet" }
+            { Chain.TestnetSoneiumMinato, "Soneium Minato Testnet" },
+            { Chain.TestnetToy, "TOY Testnet" }
         };
 
         public static Dictionary<Chain, string> GasCurrencyOf = new Dictionary<Chain, string>()
@@ -73,7 +74,8 @@ namespace Sequence
             { Chain.TestnetBlastSepolia, "ETH" },
             { Chain.TestnetBorne, "BORNE" },
             { Chain.TestnetSkaleNebulaGamingHub, "sFUEL" },
-            { Chain.TestnetSoneiumMinato, "ETH" }
+            { Chain.TestnetSoneiumMinato, "ETH" },
+            { Chain.TestnetToy, "TOY" }
         };
 
         public static Dictionary<Chain, string> BlockExplorerOf = new Dictionary<Chain, string>()
@@ -109,7 +111,8 @@ namespace Sequence
             { Chain.TestnetBlastSepolia, "https://testnet.blastscan.io/" },
             { Chain.TestnetBorne, "https://subnets-test.avax.network/bornegfdn" },
             { Chain.TestnetSkaleNebulaGamingHub, "https://green-giddy-denebola.explorer.mainnet.skalenodes.com/" },
-            { Chain.TestnetSoneiumMinato, "https://explorer-testnet.soneium.org/" }
+            { Chain.TestnetSoneiumMinato, "https://explorer-testnet.soneium.org/" },
+            { Chain.TestnetToy, "" } // Not found
         };
         
         public static Dictionary<Chain, string> ChainIdOf = new Dictionary<Chain, string>()
@@ -147,7 +150,8 @@ namespace Sequence
             { Chain.TestnetBlastSepolia, "168587773" },
             { Chain.TestnetBorne, "94984" },
             { Chain.TestnetSkaleNebulaGamingHub, "37084624" },
-            { Chain.TestnetSoneiumMinato, "1946" }
+            { Chain.TestnetSoneiumMinato, "1946" },
+            { Chain.TestnetToy, "21000000" }
         };
         
         public static Dictionary<string, Chain> ChainById = new Dictionary<string, Chain>()
@@ -183,7 +187,8 @@ namespace Sequence
             { "168587773", Chain.TestnetBlastSepolia },
             { "94984", Chain.TestnetBorne },
             { "37084624", Chain.TestnetSkaleNebulaGamingHub },
-            { "1946", Chain.TestnetSoneiumMinato }
+            { "1946", Chain.TestnetSoneiumMinato },
+            { "21000000", Chain.TestnetToy }
         };
         
         public static Dictionary<Chain, string> PathOf = new Dictionary<Chain, string>()
@@ -219,7 +224,8 @@ namespace Sequence
             { Chain.TestnetBlastSepolia, "blast-sepolia" },
             { Chain.TestnetBorne, "borne-testnet" },
             { Chain.TestnetSkaleNebulaGamingHub, "skale-nebula-testnet" },
-            { Chain.TestnetSoneiumMinato, "soneium-minato" }
+            { Chain.TestnetSoneiumMinato, "soneium-minato" },
+            { Chain.TestnetToy, "toy-testnet" }
         };
     }
 }

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Indexer/Indexer.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Indexer/Indexer.cs
@@ -81,6 +81,8 @@ namespace Sequence
         { Chain.AstarZKEvm.GetChainId(), "astar-zkevm" },
         { Chain.Xai.GetChainId(), "xai" },
         { Chain.Blast.GetChainId(), "blast" },
+        { Chain.B3.GetChainId(), "b3" },
+        { Chain.APEChain.GetChainId(), "apechain" },
 
         { Chain.TestnetSepolia.GetChainId(), "sepolia" },
         { Chain.TestnetArbitrumSepolia.GetChainId(), "arbitrum-sepolia" },

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Indexer/Indexer.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Indexer/Indexer.cs
@@ -98,7 +98,8 @@ namespace Sequence
         { Chain.TestnetBlastSepolia.GetChainId(), "blast-sepolia" },
         { Chain.TestnetBorne.GetChainId(), "borne-testnet" },
         { Chain.TestnetSkaleNebulaGamingHub.GetChainId(), "skale-nebula-testnet" },
-        { Chain.TestnetSoneiumMinato.GetChainId(), "soneium-minato" }
+        { Chain.TestnetSoneiumMinato.GetChainId(), "soneium-minato" },
+        { Chain.TestnetToy.GetChainId(), "toy-testnet" }
     };
 
         private static string _builderApiKey = SequenceConfig.GetConfig().BuilderAPIKey;

--- a/Packages/Sequence-Unity/package.json
+++ b/Packages/Sequence-Unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz.0xsequence.waas-unity",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "displayName": "Sequence Embedded Wallet SDK",
   "description": "A Unity SDK for the Sequence WaaS API",
   "unity": "2021.3",


### PR DESCRIPTION
Add B3, APE Chain, and TOY Testnet. Remove AstarZK networks as they are no longer active.