### PR TITLE
Fix broken eth client tests by replacing the public node url with one…

### DIFF
--- a/Assets/SequenceSDK/Ethereum/Tests/SequenceEthClientTests.cs
+++ b/Assets/SequenceSDK/Ethereum/Tests/SequenceEthClientTests.cs
@@ -17,7 +17,7 @@ namespace Sequence.Ethereum.Tests
     public class SequenceEthClientTests
     {
         static readonly string testnetUrl = "http://localhost:8545/";
-        static readonly string publicPolygonRpc = "https://polygon-bor.publicnode.com";
+        static readonly string publicPolygonRpc = "https://polygon-rpc.com/";
         private static string[] urls = new string[] { testnetUrl, publicPolygonRpc };
         float blockTimeInSeconds = 2f;
         IRpcClient failingClient = new FailingRpcClient();


### PR DESCRIPTION
… that works

No package version incrementing required. Change impacts tests only