### PR TITLE
DelayedEncodeData args must have any nested values alphabetically ordered

### DIFF
--- a/Assets/SequenceSDK/WaaS/Tests/DelayedEncodeJsonSerializationTest.cs
+++ b/Assets/SequenceSDK/WaaS/Tests/DelayedEncodeJsonSerializationTest.cs
@@ -1,0 +1,33 @@
+using System.Numerics;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace Sequence.EmbeddedWallet.Tests
+{
+    public class DelayedEncodeJsonSerializationTest
+    {
+        private class ComplexObjectInNonAlphabeticalOrder
+        {
+            public string LastValue;
+            public string FirstValue;
+            public string HalfwayValue;
+
+            public ComplexObjectInNonAlphabeticalOrder(string lastValue, string firstValue, string halfwayValue)
+            {
+                LastValue = lastValue;
+                FirstValue = firstValue;
+                HalfwayValue = halfwayValue;
+            }
+        }
+
+        [Test]
+        public void TestDelayedEncodeDataArgsGetsSerializedAlphabetically()
+        {
+            DelayedEncodeData testData = new DelayedEncodeData("testAbi(string,ComplexObjectInNonAlphabeticalOrder,int)", new object[] { "some string", new ComplexObjectInNonAlphabeticalOrder("last", "first", "halfway"), BigInteger.One, 5 }, "testFunc");
+            
+            string json = JsonConvert.SerializeObject(testData);
+            
+            Assert.AreEqual("{\"abi\":\"testAbi(string,ComplexObjectInNonAlphabeticalOrder,int)\",\"args\":[\"some string\",{\"FirstValue\":\"first\",\"HalfwayValue\":\"halfway\",\"LastValue\":\"last\"},1,5],\"func\":\"testFunc\"}", json);
+        }
+    }
+}

--- a/Assets/SequenceSDK/WaaS/Tests/DelayedEncodeJsonSerializationTest.cs.meta
+++ b/Assets/SequenceSDK/WaaS/Tests/DelayedEncodeJsonSerializationTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1a54c918fb6f4246b40359abe0087747
+timeCreated: 1729798030

--- a/Packages/Sequence-Unity/package.json
+++ b/Packages/Sequence-Unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz.0xsequence.waas-unity",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "displayName": "Sequence Embedded Wallet SDK",
   "description": "A Unity SDK for the Sequence WaaS API",
   "unity": "2021.3",


### PR DESCRIPTION
Failure to do this can lead to signature validation errors on the WaaS API when passing complex objects (those with multiple fields) as args