### PR TITLE
Remove properties and use simple vars instead for serializable classe…

### DIFF
--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Authentication/SignInWithApple.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Authentication/SignInWithApple.cs
@@ -11,8 +11,8 @@ namespace Sequence.Authentication
     public class SignInWithApple : MonoBehaviour
     {
         IAppleAuthManager m_AppleAuthManager;
-        public string Token { get; private set; }
-        public string Error { get; private set; }
+        public string Token;
+        public string Error;
 
         private void Initialize()
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/DelayedEncode.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/DelayedEncode.cs
@@ -4,10 +4,10 @@ namespace Sequence.EmbeddedWallet
     public class DelayedEncode : Transaction
     {
         public const string TypeIdentifier = "delayedEncode";
-        public DelayedEncodeData data { get; private set; }
-        public string to { get; private set; }
-        public string type { get; private set; } = TypeIdentifier;
-        public string value { get; private set; }
+        public DelayedEncodeData data;
+        public string to;
+        public string type = TypeIdentifier;
+        public string value;
         
         public DelayedEncode(string contractAddress, string value, DelayedEncodeData data)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/Identity.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/Identity.cs
@@ -5,10 +5,10 @@ namespace Sequence.EmbeddedWallet
     [Serializable]
     public class Identity
     {
-        public string type { get; private set; }
-        public string iss { get; private set; }
-        public string sub { get; private set; }
-        public string email { get; private set; }
+        public string type;
+        public string iss;
+        public string sub;
+        public string email;
 
         public Identity(string type, string iss, string sub, string email)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/IntentDataCloseSession.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/IntentDataCloseSession.cs
@@ -5,7 +5,7 @@ namespace Sequence.EmbeddedWallet
     [Serializable]
     public class IntentDataCloseSession
     {
-        public string sessionId { get; private set; }
+        public string sessionId;
 
         public IntentDataCloseSession(string sessionId)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/IntentDataFeeOptions.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/IntentDataFeeOptions.cs
@@ -5,10 +5,10 @@ namespace Sequence.EmbeddedWallet
 {
     public class IntentDataFeeOptions
     {
-        public string identifier { get; private set; }
-        public string network { get; private set; }
-        public Transaction[] transactions { get; private set; }
-        public string wallet { get; private set; }
+        public string identifier;
+        public string network;
+        public Transaction[] transactions;
+        public string wallet;
         
         [JsonConstructor]
         public IntentDataFeeOptions(string identifier, string network, Transaction[] transactions, string wallet)

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/IntentDataFinishValidateSession.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/IntentDataFinishValidateSession.cs
@@ -5,10 +5,10 @@ namespace Sequence.EmbeddedWallet
     [Serializable]
     public class IntentDataFinishValidateSession
     {
-        public string sessionId { get; private set; }
-        public string wallet { get; private set; }
-        public string salt { get; private set; }
-        public string challenge { get; private set; }
+        public string sessionId;
+        public string wallet;
+        public string salt;
+        public string challenge;
 
         public IntentDataFinishValidateSession(string sessionId, string wallet, string salt, string challenge)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/IntentDataGetIdToken.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/IntentDataGetIdToken.cs
@@ -5,9 +5,9 @@ namespace Sequence.EmbeddedWallet
     [Serializable]
     public class IntentDataGetIdToken
     {
-        public string sessionId { get; private set; }
-        public string wallet { get; private set; }
-        public string nonce { get; private set; } 
+        public string sessionId;
+        public string wallet;
+        public string nonce;
 
         public IntentDataGetIdToken(string sessionId, string walletAddress, string nonce = null)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/IntentDataGetSession.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/IntentDataGetSession.cs
@@ -5,8 +5,8 @@ namespace Sequence.EmbeddedWallet
     [Serializable]
     public class IntentDataGetSession
     {
-        public string sessionId { get; private set; }
-        public string wallet { get; private set; }
+        public string sessionId;
+        public string wallet;
 
         public IntentDataGetSession(string sessionId, string walletAddress)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/IntentDataGetTransactionReceipt.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/IntentDataGetTransactionReceipt.cs
@@ -6,9 +6,9 @@ namespace Sequence.EmbeddedWallet
     [Serializable]
     public class IntentDataGetTransactionReceipt
     {
-        public string metaTxHash { get; private set; }
-        public string network { get; private set; }
-        public string wallet { get; private set; }
+        public string metaTxHash;
+        public string network;
+        public string wallet;
 
         public IntentDataGetTransactionReceipt(string metaTxHash, string network, string wallet)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/IntentDataListSessions.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/IntentDataListSessions.cs
@@ -5,7 +5,7 @@ namespace Sequence.EmbeddedWallet
     [Serializable]
     public class IntentDataListSessions
     {
-        public string wallet { get; private set; }
+        public string wallet;
         
         public IntentDataListSessions(string walletAddress)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/IntentDataSendTransaction.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/IntentDataSendTransaction.cs
@@ -7,11 +7,11 @@ namespace Sequence.EmbeddedWallet
     [System.Serializable]
     public class IntentDataSendTransaction
     {
-        public string identifier { get; private set; } = Guid.NewGuid().ToString();
-        public string network { get; private set; }
-        public Transaction[] transactions { get; private set; }
-        public string transactionsFeeQuote { get; private set; }
-        public string wallet { get; private set; }
+        public string identifier = Guid.NewGuid().ToString();
+        public string network;
+        public Transaction[] transactions;
+        public string transactionsFeeQuote;
+        public string wallet;
 
         public static readonly string transactionTypeIdentifier = "type";
 

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/IntentDataSignMessage.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/IntentDataSignMessage.cs
@@ -7,9 +7,9 @@ namespace Sequence.EmbeddedWallet
     [Serializable]
     public class IntentDataSignMessage
     {
-        public string message { get; private set; }
-        public string network { get; private set; }
-        public string wallet { get; private set; }
+        public string message;
+        public string network;
+        public string wallet;
 
         public IntentDataSignMessage(string walletAddress, Chain network, string message)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/IntentDataValidateSession.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/IntentDataValidateSession.cs
@@ -5,9 +5,9 @@ namespace Sequence.EmbeddedWallet
     [Serializable]
     public class IntentDataValidateSession
     {
-        public string deviceMetadata { get; private set; }
-        public string sessionId { get; private set; }
-        public string wallet { get; private set; }
+        public string deviceMetadata;
+        public string sessionId;
+        public string wallet;
 
         public IntentDataValidateSession(string sessionId, string wallet, string deviceMetadata)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/IntentPayload.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/IntentPayload.cs
@@ -8,12 +8,12 @@ namespace Sequence.EmbeddedWallet
     [Serializable]
     public class IntentPayload
     {
-        public JObject data { get; private set; }
-        public uint expiresAt { get; private set; }
-        public uint issuedAt { get; private set; }
-        public string name { get; private set; }
-        public Signature[] signatures { get; private set; }
-        public string version { get; private set; }
+        public JObject data;
+        public uint expiresAt;
+        public uint issuedAt;
+        public string name;
+        public Signature[] signatures;
+        public string version;
 
         [JsonConstructor]
         public IntentPayload(string version, string name, uint expiresAt, uint issuedAt, JObject data, Signature[] signatures)

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/RawTransaction.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/RawTransaction.cs
@@ -10,10 +10,10 @@ namespace Sequence.EmbeddedWallet
     public class RawTransaction : Transaction
     {
         public const string TypeIdentifier = "transaction";
-        public string data { get; private set; }
-        public string to { get; private set; }
-        public string type { get; private set; } = TypeIdentifier;
-        public string value { get; private set; }
+        public string data;
+        public string to;
+        public string type = TypeIdentifier;
+        public string value;
 
         public RawTransaction(string to, string value = null, string calldata = null)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/RegisterSessionIntent.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/RegisterSessionIntent.cs
@@ -2,8 +2,8 @@ namespace Sequence.EmbeddedWallet
 {
     public class RegisterSessionIntent
     {
-        public IntentPayload intent { get; private set; }
-        public string friendlyName { get; private set; }
+        public IntentPayload intent;
+        public string friendlyName;
         
         public RegisterSessionIntent(string friendlyName, IntentPayload intent)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/SendERC1155.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/SendERC1155.cs
@@ -7,11 +7,11 @@ namespace Sequence.EmbeddedWallet
     public class SendERC1155 : Transaction
     {
         public const string TypeIdentifier = "erc1155send";
-        public string data { get; private set; }
-        public string to { get; private set; }
-        public string tokenAddress { get; private set; }
-        public string type { get; private set; } = TypeIdentifier;
-        public SendERC1155Values[] vals { get; private set; }
+        public string data;
+        public string to;
+        public string tokenAddress;
+        public string type = TypeIdentifier;
+        public SendERC1155Values[] vals;
 
         public SendERC1155(string tokenAddress, string to, SendERC1155Values[] sendErc1155Values, string data = null)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/SendERC1155Values.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/SendERC1155Values.cs
@@ -5,8 +5,8 @@ namespace Sequence.EmbeddedWallet
     [Serializable]
     public class SendERC1155Values
     {
-        public string amount { get; private set; }
-        public string id { get; private set; }
+        public string amount;
+        public string id;
 
         public SendERC1155Values(string id, string amount)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/SendERC20.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/SendERC20.cs
@@ -6,10 +6,10 @@ namespace Sequence.EmbeddedWallet
     public class SendERC20 : Transaction
     {
         public const string TypeIdentifier = "erc20send";
-        public string to { get; private set; }
-        public string tokenAddress { get; private set; }
-        public string type { get; private set; } = TypeIdentifier;
-        public string value { get; private set; }
+        public string to;
+        public string tokenAddress;
+        public string type = TypeIdentifier;
+        public string value;
         
         public SendERC20(string tokenAddress, string to, string value)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/SendERC721.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/SendERC721.cs
@@ -8,12 +8,12 @@ namespace Sequence.EmbeddedWallet
     public class SendERC721 : Transaction
     {
         public const string TypeIdentifier = "erc721send";
-        public string data { get; private set; }
-        public string id { get; private set; }
-        public bool safe { get; private set; }
-        public string to { get; private set; }
-        public string tokenAddress { get; private set; }
-        public string type { get; private set; } = TypeIdentifier;
+        public string data;
+        public string id;
+        public bool safe;
+        public string to;
+        public string tokenAddress;
+        public string type = TypeIdentifier;
         
         public SendERC721(string tokenAddress, string to, string tokenId, bool safe = true, string data = null)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/SendIntentPayload.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/SendIntentPayload.cs
@@ -5,7 +5,7 @@ namespace Sequence.EmbeddedWallet
     [Serializable]
     public class SendIntentPayload
     {
-        public IntentPayload intent {get; private set;}
+        public IntentPayload intent;
         
         public SendIntentPayload(IntentPayload intent)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/Signature.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ParameterTypes/Signature.cs
@@ -2,8 +2,8 @@ namespace Sequence.EmbeddedWallet
 {
     public class Signature
     {
-        public string sessionId { get; private set; }
-        public string signature { get; private set; }
+        public string sessionId;
+        public string signature;
         
         public Signature(string sessionId, string signature)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/FailedTransactionReturn.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/FailedTransactionReturn.cs
@@ -7,9 +7,9 @@ namespace Sequence.EmbeddedWallet
     public class FailedTransactionReturn : TransactionReturn
     {
         public const string IdentifyingCode = "transactionFailed";
-        public string error { get; private set; }
-        public IntentPayload request { get; private set; }
-        public SimulateResult[] simulations { get; private set; }
+        public string error;
+        public IntentPayload request;
+        public SimulateResult[] simulations;
 
         [JsonConstructor]
         public FailedTransactionReturn(string error, IntentPayload request, SimulateResult[] simulations)
@@ -33,9 +33,9 @@ namespace Sequence.EmbeddedWallet
 
     public class FailedBatchTransactionReturn : FailedTransactionReturn
     {
-        public SuccessfulTransactionReturn[] SuccessfulTransactionReturns { get; private set; }
+        public SuccessfulTransactionReturn[] SuccessfulTransactionReturns;
 
-        public FailedTransactionReturn[] FailedTransactionReturns { get; private set; }
+        public FailedTransactionReturn[] FailedTransactionReturns;
 
         public FailedBatchTransactionReturn(SuccessfulTransactionReturn[] successfullTransactionReturns, FailedTransactionReturn[] failedTransactionReturns)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/FeeOption.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/FeeOption.cs
@@ -5,10 +5,10 @@ namespace Sequence.EmbeddedWallet
     [Serializable]
     public class FeeOption
     {
-        public uint gasLimit { get; private set; }
-        public string to { get; private set; }
-        public FeeToken token { get; private set; }
-        public string value { get; private set; }
+        public uint gasLimit;
+        public string to;
+        public FeeToken token;
+        public string value;
 
         public FeeOption(uint gasLimit, string to, FeeToken token, string value)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/FeeOptionReturn.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/FeeOptionReturn.cs
@@ -5,8 +5,8 @@ namespace Sequence.EmbeddedWallet
     [Serializable]
     public class FeeOptionReturn
     {
-        public FeeOption FeeOption { get; private set; }
-        public bool InWallet { get; private set; }
+        public FeeOption FeeOption;
+        public bool InWallet;
 
         public FeeOptionReturn(FeeOption feeOption, bool inWallet)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/FeeOptionsResponse.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/FeeOptionsResponse.cs
@@ -5,8 +5,8 @@ namespace Sequence.EmbeddedWallet
     [Serializable]
     public class FeeOptionsResponse
     {
-        public FeeOptionReturn[] FeeOptions { get; private set; }
-        public string FeeQuote { get; private set; }
+        public FeeOptionReturn[] FeeOptions;
+        public string FeeQuote;
 
         public FeeOptionsResponse(FeeOptionReturn[] feeOptions, string feeQuote)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/FeeToken.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/FeeToken.cs
@@ -5,14 +5,14 @@ namespace Sequence.EmbeddedWallet
 {
     public class FeeToken
     {
-        public uint chainId { get; private set; }
-        public string contractAddress { get; private set; }
-        public uint decimals { get; private set; }
-        public string logoURL { get; private set; }
-        public string name { get; private set; }
-        public string symbol { get; private set; }
-        public string tokenID { get; private set; }
-        public FeeTokenType type { get; private set; }
+        public uint chainId;
+        public string contractAddress;
+        public uint decimals;
+        public string logoURL;
+        public string name;
+        public string symbol;
+        public string tokenID;
+        public FeeTokenType type;
 
         [JsonConstructor]
         public FeeToken(uint chainId, string contractAddress, uint decimals, string logoURL, string name, string symbol, string tokenID, FeeTokenType type)

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/IntentResponse.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/IntentResponse.cs
@@ -6,18 +6,19 @@ namespace Sequence.EmbeddedWallet
     [Serializable]
     public class IntentResponse<T>
     {
-        public Response<T> response { get; private set; }
+        public Response<T> response;
 
         public IntentResponse(Response<T> response)
         {
             this.response = response;
         }
     }
-    
+
+    [Serializable]
     public class Response<T>
     {
-        public string code { get; private set; }
-        public T data { get; private set; }
+        public string code;
+        public T data;
         
         public Response(string code, T data)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/IntentResponseFeeOptions.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/IntentResponseFeeOptions.cs
@@ -6,8 +6,8 @@ namespace Sequence.EmbeddedWallet
     [Serializable]
     public class IntentResponseFeeOptions
     {
-        public FeeOption[] feeOptions { get; private set; }
-        public string feeQuote { get; private set; }
+        public FeeOption[] feeOptions;
+        public string feeQuote;
 
         public IntentResponseFeeOptions(FeeOption[] feeOptions, string feeQuote)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/IntentResponseGetGetIdToken.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/IntentResponseGetGetIdToken.cs
@@ -5,8 +5,8 @@ namespace Sequence.EmbeddedWallet
     [Serializable]
     public class IntentResponseGetIdToken
     {
-        public string IdToken { get; private set; }
-        public int ExpiresIn { get; private set; }
+        public string IdToken;
+        public int ExpiresIn;
 
         public IntentResponseGetIdToken(string idToken, int expiresIn)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/IntentResponseGetSession.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/IntentResponseGetSession.cs
@@ -5,9 +5,9 @@ namespace Sequence.EmbeddedWallet
     [Serializable]
     public class IntentResponseGetSession
     {
-        public string sessionId { get; private set; }
-        public string wallet { get; private set; }
-        public bool validated { get; private set; }
+        public string sessionId;
+        public string wallet;
+        public bool validated;
         
         public IntentResponseGetSession(string sessionId, string wallet, bool validated)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/IntentResponseValidationFinished.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/IntentResponseValidationFinished.cs
@@ -2,7 +2,7 @@ namespace Sequence.EmbeddedWallet
 {
     public class IntentResponseValidationFinished
     {
-        public bool isValid { get; private set; }
+        public bool isValid;
         
         public IntentResponseValidationFinished(bool isValid)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/IntentResponseValidationRequired.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/IntentResponseValidationRequired.cs
@@ -5,7 +5,7 @@ namespace Sequence.EmbeddedWallet
     [Serializable]
     public class IntentResponseValidationRequired
     {
-        public string sessionId { get; private set; }
+        public string sessionId;
 
         public IntentResponseValidationRequired(string sessionId)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/IntentResponseValidationStarted.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/IntentResponseValidationStarted.cs
@@ -5,7 +5,7 @@ namespace Sequence.EmbeddedWallet
     [Serializable]
     public class IntentResponseValidationStarted
     {
-        public string salt { get; private set; }
+        public string salt;
         
         public IntentResponseValidationStarted(string salt)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/IsValidMessageSignatureReturn.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/IsValidMessageSignatureReturn.cs
@@ -3,7 +3,7 @@ namespace Sequence.EmbeddedWallet
     [System.Serializable]
     public class IsValidMessageSignatureReturn
     {
-        public bool isValid { get; set; }
+        public bool isValid;
         public IsValidMessageSignatureReturn(bool IsValid)
         {
              isValid =  IsValid;

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/MetaTxnReceipt.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/MetaTxnReceipt.cs
@@ -3,13 +3,13 @@ namespace Sequence.EmbeddedWallet
     [System.Serializable]
     public class MetaTxnReceipt
     {
-        public string id { get; private set; }
-        public string status { get; private set; }
-        public string revertReason { get; private set; }
-        public int index { get; private set; }
-        public MetaTxnReceiptLog[] logs { get; private set; }
-        public MetaTxnReceipt[] receipts { get; private set; }
-        public string txnReceipt { get; private set; }
+        public string id;
+        public string status;
+        public string revertReason;
+        public int index;
+        public MetaTxnReceiptLog[] logs;
+        public MetaTxnReceipt[] receipts;
+        public string txnReceipt;
 
         public MetaTxnReceipt(string id, string status, int index, MetaTxnReceiptLog[] logs, MetaTxnReceipt[] receipts, string txnReceipt, string revertReason = null)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/MetaTxnReceiptLog.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/MetaTxnReceiptLog.cs
@@ -3,15 +3,15 @@ namespace Sequence.EmbeddedWallet
     [System.Serializable]
     public class MetaTxnReceiptLog
     {
-        public string address { get; private set; }
-        public string[] topics { get; private set; }
-        public string data { get; private set; }
-        public uint blockNumber { get; private set; }
-        public string transactionHash { get; private set; }
-        public uint transactionIndex { get; private set; }
-        public string blockHash { get; private set; }
-        public uint logIndex { get; private set; }
-        public bool removed { get; private set; }
+        public string address;
+        public string[] topics;
+        public string data;
+        public uint blockNumber;
+        public string transactionHash;
+        public uint transactionIndex;
+        public string blockHash;
+        public uint logIndex;
+        public bool removed;
         
         public MetaTxnReceiptLog(string address, string[] topics, string data, uint blockNumber, string transactionHash, uint transactionIndex, string blockHash, uint logIndex, bool removed)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/RegisterSessionResponse.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/RegisterSessionResponse.cs
@@ -2,8 +2,8 @@ namespace Sequence.EmbeddedWallet
 {
     public class RegisterSessionResponse
     {
-        public Session session { get; private set; }
-        public Response<IntentResponseSessionOpened> response { get; private set; }
+        public Session session;
+        public Response<IntentResponseSessionOpened> response;
         
         public RegisterSessionResponse(Session session, Response<IntentResponseSessionOpened> response)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/SimulateResult.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/SimulateResult.cs
@@ -3,12 +3,12 @@ namespace Sequence.EmbeddedWallet
     [System.Serializable]
     public class SimulateResult
     {
-        public bool executed { get; private set; }
-        public bool succeeded { get; private set; }
-        public string result { get; private set; }
-        public string reason { get; private set; }
-        public uint gasUsed { get; private set; }
-        public uint gasLimit { get; private set; }
+        public bool executed;
+        public bool succeeded;
+        public string result;
+        public string reason;
+        public uint gasUsed;
+        public uint gasLimit;
 
         public SimulateResult(bool executed, bool succeeded, uint gasUsed, uint gasLimit, string result = null, string reason = null)
         {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/SuccessfulTransactionReturn.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/SuccessfulTransactionReturn.cs
@@ -10,15 +10,16 @@ namespace Sequence.EmbeddedWallet
     public class SuccessfulTransactionReturn : TransactionReturn
     {
         public const string IdentifyingCode = "transactionReceipt";
-        public string txHash { get; private set; }
-        public string metaTxHash { get; private set; }
-        public IntentPayload request { get; private set; }
-        public MetaTxnReceipt receipt { get; private set; }
+        public string txHash;
+        public string metaTxHash;
+        public IntentPayload request;
+        public MetaTxnReceipt receipt;
 
         [Obsolete("nativeReceipt is deprecated. Please use nativeTransactionReceipt instead.")]
-        public JObject nativeReceipt { get; private set; }
-        public TransactionReceipt nativeTransactionReceipt { get; private set; }
-        public SimulateResult[] simulations { get; private set; }
+        public JObject nativeReceipt;
+
+        public TransactionReceipt nativeTransactionReceipt;
+        public SimulateResult[] simulations;
 
         public SuccessfulTransactionReturn() { }
 

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Ethereum/Provider/RpcError.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Ethereum/Provider/RpcError.cs
@@ -3,8 +3,8 @@ namespace Sequence.Provider
 {
     public class RpcError
     {
-        public int Code { get; set; }
-        public string Message { get; set; }
+        public int Code;
+        public string Message;
     }
 
 }

--- a/Packages/Sequence-Unity/package.json
+++ b/Packages/Sequence-Unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz.0xsequence.waas-unity",
-  "version": "3.10.3",
+  "version": "3.10.4",
   "displayName": "Sequence Embedded Wallet SDK",
   "description": "A Unity SDK for the Sequence WaaS API",
   "unity": "2021.3",

--- a/Packages/Sequence-Unity/package.json
+++ b/Packages/Sequence-Unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz.0xsequence.waas-unity",
-  "version": "3.10.2",
+  "version": "3.10.3",
   "displayName": "Sequence Embedded Wallet SDK",
   "description": "A Unity SDK for the Sequence WaaS API",
   "unity": "2021.3",


### PR DESCRIPTION
…d - on iOS, there is a unity bug that occasionally causes issues with JSON serialization/deserialization of properties