### PR TITLE
Fix an annoying bug where tests would fail if secure storage in the e…

### DIFF
--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Config/SequenceConfig.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Config/SequenceConfig.cs
@@ -1,4 +1,6 @@
 using System;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
 using UnityEngine;
 using UnityEngine.Serialization;
 
@@ -75,7 +77,8 @@ namespace Sequence.Config
         public bool StoreSessionKey()
         {
 #if UNITY_EDITOR
-            return EditorStoreSessionPrivateKeyInSecureStorage;
+            return EditorStoreSessionPrivateKeyInSecureStorage &&
+                   TestContext.CurrentTestExecutionContext?.ExecutionStatus != TestExecutionStatus.Running;
 #else
             return StoreSessionPrivateKeyInSecureStorage;
 #endif

--- a/Packages/Sequence-Unity/package.json
+++ b/Packages/Sequence-Unity/package.json
@@ -6,7 +6,8 @@
   "unity": "2021.3",
   "keywords": ["Unity", "Package", "wallet", "ethereum", "web3", "sequence", "waas", "oidc"],
   "dependencies": {
-    "com.unity.nuget.newtonsoft-json" : "3.0.2"
+    "com.unity.nuget.newtonsoft-json" : "3.0.2",
+    "com.unity.test-framework": "1.3.4"
   },
   "author": {
     "name": "0xsequence",

--- a/Packages/Sequence-Unity/package.json
+++ b/Packages/Sequence-Unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz.0xsequence.waas-unity",
-  "version": "3.10.3",
+  "version": "3.10.4",
   "displayName": "Sequence Embedded Wallet SDK",
   "description": "A Unity SDK for the Sequence WaaS API",
   "unity": "2021.3",


### PR DESCRIPTION
…ditor was enabled as we were attempting to sign in but the user was already authenticated (via restored session) - fixed by checking if tests are running when fetching the config