### PR TITLE
Use unityengine's assertion not the NUnit framework assertion as this…

### DIFF
--- a/Packages/Sequence-Unity/Sequence/SequenceFrontend/Scripts/UI/Demos/PrimarySales/PrimarySaleStateERC1155.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceFrontend/Scripts/UI/Demos/PrimarySales/PrimarySaleStateERC1155.cs
@@ -2,11 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Numerics;
 using System.Threading.Tasks;
-using NUnit.Framework;
 using Sequence.Contracts;
 using Sequence.EmbeddedWallet;
 using Sequence.Provider;
 using UnityEngine;
+using UnityEngine.Assertions;
 
 namespace Sequence.Demo
 {

--- a/Packages/Sequence-Unity/package.json
+++ b/Packages/Sequence-Unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz.0xsequence.waas-unity",
-  "version": "3.11.2",
+  "version": "3.11.3",
   "displayName": "Sequence Embedded Wallet SDK",
   "description": "A Unity SDK for the Sequence WaaS API",
   "unity": "2021.3",


### PR DESCRIPTION
… can cause assembly issues during builds (as NUnit.framework is not usually included)