### PR TITLE
Set package version in resources folder when compiling

### DIFF
--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Config/Editor/VersionSetter.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Config/Editor/VersionSetter.cs
@@ -1,17 +1,23 @@
 using UnityEditor;
 using System.IO;
-using UnityEditor.Callbacks;
+using UnityEngine;
 
 namespace Sequence.Config.Editor
 {
-    public static class VersionSetter 
+    [InitializeOnLoad]
+    public static class VersionSetter
     {
-        [PostProcessBuild]
-        public static void OnPostProcessBuild(BuildTarget target, string pathToBuiltProject)
+        static VersionSetter()
         {
-            InjectSDKVersionIntoResources();
+            UpdateVersionFileOnImport();
         }
 
+        private static void UpdateVersionFileOnImport()
+        {
+            EditorApplication.delayCall += InjectSDKVersionIntoResources;
+        }
+
+        // Because of the InitializeOnLoad attribute, this method will be called whenever code is recompiled in the editor
         private static void InjectSDKVersionIntoResources()
         {
             string version = PackageVersionReader.GetVersion();

--- a/Packages/Sequence-Unity/package.json
+++ b/Packages/Sequence-Unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz.0xsequence.waas-unity",
-  "version": "3.11.3",
+  "version": "3.11.4",
   "displayName": "Sequence Embedded Wallet SDK",
   "description": "A Unity SDK for the Sequence WaaS API",
   "unity": "2021.3",


### PR DESCRIPTION
Previously this was done when building but could potentially cause build errors or the version could be out of sync. With this change, the package version will be set any time the project code is recompiled

An easy way to test this is to delete the "Assets/Resources/sequence-unity-version.txt" file and then change some code (anywhere, even in the assets folder) then return to the editor. Once the editor has recompiled the code, you should see that the file is back.