### PR TITLE
Removed '@' when finding package directory

### DIFF
--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Config/PackageVersionReader.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Config/PackageVersionReader.cs
@@ -27,7 +27,7 @@ namespace Sequence.Config
                 return packagesPath;
             }
 
-            string[] directories = Directory.GetDirectories("Library/PackageCache/", "xyz.0xsequence.waas-unity@*", SearchOption.TopDirectoryOnly);
+            string[] directories = Directory.GetDirectories("Library/PackageCache/", "xyz.0xsequence.waas-unity*", SearchOption.TopDirectoryOnly);
 
             if (directories.Length > 0)
             {

--- a/Packages/Sequence-Unity/package.json
+++ b/Packages/Sequence-Unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz.0xsequence.waas-unity",
-  "version": "3.11.6",
+  "version": "3.11.7",
   "displayName": "Sequence Embedded Wallet SDK",
   "description": "A Unity SDK for the Sequence WaaS API",
   "unity": "2021.3",


### PR DESCRIPTION
Unity 6 stores packages without appending the version/hash to it.