### PR TITLE
Fixed indexer runtime status test; the server is currently returning …

### DIFF
--- a/Assets/SequenceSDK/Indexer/Tests/ChainIndexerTests.cs
+++ b/Assets/SequenceSDK/Indexer/Tests/ChainIndexerTests.cs
@@ -94,7 +94,6 @@ namespace Sequence.Indexer.Tests
             Assert.IsTrue(result.indexerEnabled);
             Assert.IsTrue(result.healthOK);
             Assert.IsFalse(string.IsNullOrWhiteSpace(result.startTime));
-            Assert.IsFalse(string.IsNullOrWhiteSpace(result.ver));
             Assert.IsFalse(string.IsNullOrWhiteSpace(result.branch));
             Assert.IsFalse(string.IsNullOrWhiteSpace(result.commitHash));
             Assert.AreEqual(chain.GetChainId(), result.chainID);


### PR DESCRIPTION
…an incorrect value for the 'ver' field; since this value isn't very important for our use case, I've simply removed it from the test so that we don't get a bunch of test fails.

No version increment needed - change impacts tests only

### Docs Checklist
Please ensure you have addressed documentation updates if needed as part of this PR:
- [ ] I have created a separate PR on the sequence docs repository for documentation updates: [Link to docs PR](https://github.com/0xsequence/docs/pulls)
- [x] No documentation update is needed for this change.
