### PR TITLE
Only reset session id if there is no connected wallet address - witho…

### DIFF
--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/SequenceLogin.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/SequenceLogin.cs
@@ -108,6 +108,9 @@ namespace Sequence.EmbeddedWallet
 
         public void ResetSessionId()
         {
+            if (_connectedWalletAddress != null) {
+                return;
+            }
             _sessionWallet = new EOAWallet();
             _sessionId = IntentDataOpenSession.CreateSessionId(_sessionWallet.GetAddress());
             _intentSender = new IntentSender(new HttpClient(WaaSWithAuthUrl), _sessionWallet, _sessionId, _waasProjectId, _waasVersion);

--- a/Packages/Sequence-Unity/package.json
+++ b/Packages/Sequence-Unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz.0xsequence.waas-unity",
-  "version": "3.17.4",
+  "version": "3.17.5",
   "displayName": "Sequence Embedded Wallet SDK",
   "description": "A Unity SDK for the Sequence WaaS API",
   "unity": "2021.3",


### PR DESCRIPTION
…ut this, the flow to re-use the login panel from our docs (setting a connected wallet address) is broken - the waas api will reject the federate auth attempt as you will be using an un-authenticated session id

### Version Increment
Please ensure you have incremented the package version in the package.json as necessary.
- [x] I have incremented the package.json according to [semantic versioning](https://docs.unity3d.com/Manual/upm-semver.html)
- [ ] No version increment is needed; the change does not impact SDK or Sample code/assets

### Docs Checklist
Please ensure you have addressed documentation updates if needed as part of this PR:
- [ ] I have created a separate PR on the sequence docs repository for documentation updates: [Link to docs PR](https://github.com/0xsequence/docs/pulls)
- [x] No documentation update is needed for this change.
