### PR TITLE
Fix/address dictionary

### DIFF
--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Ethereum/Address/Address.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Ethereum/Address/Address.cs
@@ -40,7 +40,12 @@ namespace Sequence {
             }
 
             Address address = (Address)obj;
-            return this.Value == address.Value;
+            return Value.Equals(address.Value, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override int GetHashCode()
+        {
+            return Value.ToLowerInvariant().GetHashCode();
         }
     }
 

--- a/Packages/Sequence-Unity/package.json
+++ b/Packages/Sequence-Unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz.0xsequence.waas-unity",
-  "version": "3.19.0",
+  "version": "3.19.1",
   "displayName": "Sequence Embedded Wallet SDK",
   "description": "A Unity SDK for the Sequence WaaS API",
   "unity": "2021.3",


### PR DESCRIPTION
Add an override for Address.GetHashCode() -> this allows us to use `Address`es as keys for dictionaries

### Version Increment
Please ensure you have incremented the package version in the package.json as necessary.
- [x] I have incremented the package.json according to [semantic versioning](https://docs.unity3d.com/Manual/upm-semver.html)
- [ ] No version increment is needed; the change does not impact SDK or Sample code/assets

### Docs Checklist
Please ensure you have addressed documentation updates if needed as part of this PR:
- [ ] I have created a separate PR on the sequence docs repository for documentation updates: [Link to docs PR](https://github.com/0xsequence/docs/pulls)
- [x] No documentation update is needed for this change.
