### PR TITLE
Cache config objects in a dictionary so we can load multiple configs …

### DIFF
--- a/Assets/SequenceSDK/WaaS/Tests/IntentSenderTests.cs
+++ b/Assets/SequenceSDK/WaaS/Tests/IntentSenderTests.cs
@@ -138,7 +138,7 @@ namespace Sequence.EmbeddedWallet.Tests
         public async Task TestTimeMismatchExceptionResultsInRetry(int timeOffset)
         {
             SequenceConfig config = SequenceConfig.GetConfig(SequenceService.WaaS);
-            ConfigJwt configJwt = SequenceConfig.GetConfigJwt();
+            ConfigJwt configJwt = SequenceConfig.GetConfigJwt(config);
             IntentSender intentSender = new IntentSender(new HttpClient($"{configJwt.rpcServer.AppendTrailingSlashIfNeeded()}rpc/WaasAuthenticator"), new EOAWallet(), "", configJwt.projectId, config.WaaSVersion);
             LogAssert.Expect(LogType.Warning, new Regex("Time mismatch*"));
             try

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Config/SequenceConfig.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Config/SequenceConfig.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 using UnityEditor;
@@ -33,13 +34,18 @@ namespace Sequence.Config
         public bool StoreSessionPrivateKeyInSecureStorage = false;
         public bool EditorStoreSessionPrivateKeyInSecureStorage = false;
         
-        private static SequenceConfig _config;
+        private static Dictionary<SequenceService, SequenceConfig> _configs = new Dictionary<SequenceService, SequenceConfig>();
         public static SequenceConfig GetConfig(SequenceService sequenceService = SequenceService.Unspecified)
         {
-            if (_config == null)
+            if (_configs.TryGetValue(sequenceService, out SequenceConfig cachedConfig))
             {
-                _config = GetAppropriateConfig(sequenceService);
-                if (_config == null)
+                return cachedConfig;
+            }
+            else 
+            {
+                _configs[sequenceService] = GetAppropriateConfig(sequenceService);
+                SequenceConfig config = _configs[sequenceService];
+                if (config == null)
                 {
                     throw new Exception("SequenceConfig not found. Make sure to create and configure it and place it at the root of your Resources folder. Create it from the top bar with Assets > Create > Sequence > SequenceConfig");
                 }
@@ -47,19 +53,18 @@ namespace Sequence.Config
                 TextAsset versionFile = Resources.Load<TextAsset>("sequence-unity-version");
                 if (versionFile != null)
                 {
-                    _config.WaaSVersion = $"1 (Unity {versionFile.text})";
+                    config.WaaSVersion = $"1 (Unity {versionFile.text})";
                 }
                 else
                 {
-                    _config.WaaSVersion = $"1 (Unity {PackageVersionReader.GetVersion()})";
+                    config.WaaSVersion = $"1 (Unity {PackageVersionReader.GetVersion()})";
                 }
                 
 #if UNITY_EDITOR
-                _config.WaaSVersion = $"1 (Unity {PackageVersionReader.GetVersion()})"; // version file is only updated when building
+                config.WaaSVersion = $"1 (Unity {PackageVersionReader.GetVersion()})"; // version file is only updated when building
 #endif
+                return config;
             }
-
-            return _config;
         }
 
         private static SequenceConfig GetAppropriateConfig(SequenceService sequenceService)
@@ -140,9 +145,15 @@ namespace Sequence.Config
             return new Exception($"{valueName} is not set. Please set it in SequenceConfig asset in your Resources folder.");
         }
 
-        public static ConfigJwt GetConfigJwt()
+        public static ConfigJwt GetConfigJwt(SequenceService service = SequenceService.Unspecified)
         {
-            string configKey = _config.WaaSConfigKey;
+            SequenceConfig config = GetConfig(service);
+            return GetConfigJwt(config);
+        }
+
+        public static ConfigJwt GetConfigJwt(SequenceConfig config)
+        {
+            string configKey = config.WaaSConfigKey;
             if (string.IsNullOrWhiteSpace(configKey))
             {
                 throw SequenceConfig.MissingConfigError("WaaS Config Key");

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/HttpClient.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/HttpClient.cs
@@ -46,7 +46,7 @@ namespace Sequence.EmbeddedWallet
                 throw SequenceConfig.MissingConfigError("Builder API Key");
             }
             
-            ConfigJwt configJwt = SequenceConfig.GetConfigJwt();
+            ConfigJwt configJwt = SequenceConfig.GetConfigJwt(config);
             string rpcUrl = configJwt.rpcServer;
             if (string.IsNullOrWhiteSpace(rpcUrl))
             {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/SequenceLogin.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/SequenceLogin.cs
@@ -128,7 +128,7 @@ namespace Sequence.EmbeddedWallet
 
         public void SetupAuthenticator(IValidator validator = null, IAuthenticator authenticator = null)
         {
-            ConfigJwt configJwt = SequenceConfig.GetConfigJwt();
+            ConfigJwt configJwt = SequenceConfig.GetConfigJwt(SequenceConfig.GetConfig(SequenceService.WaaS));
             if (_connectedWalletAddress == null || _sessionWallet == null)
             {
                 _sessionWallet = new EOAWallet();
@@ -198,7 +198,7 @@ namespace Sequence.EmbeddedWallet
             }
             _waasVersion = waasVersion;
 
-            ConfigJwt configJwt = SequenceConfig.GetConfigJwt();
+            ConfigJwt configJwt = SequenceConfig.GetConfigJwt(config);
 
             string rpcUrl = configJwt.rpcServer;
             if (string.IsNullOrWhiteSpace(rpcUrl))

--- a/Packages/Sequence-Unity/package.json
+++ b/Packages/Sequence-Unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz.0xsequence.waas-unity",
-  "version": "3.19.2",
+  "version": "3.19.3",
   "displayName": "Sequence Embedded Wallet SDK",
   "description": "A Unity SDK for the Sequence WaaS API",
   "unity": "2021.3",


### PR DESCRIPTION
…at once and target different envs for different services successfully

### Version Increment
Please ensure you have incremented the package version in the package.json as necessary.
- [x] I have incremented the package.json according to [semantic versioning](https://docs.unity3d.com/Manual/upm-semver.html)
- [ ] No version increment is needed; the change does not impact SDK or Sample code/assets

### Docs Checklist
Please ensure you have addressed documentation updates if needed as part of this PR:
- [ ] I have created a separate PR on the sequence docs repository for documentation updates: [Link to docs PR](https://github.com/0xsequence/docs/pulls)
- [x] No documentation update is needed for this change.
