### PR TITLE
Fix/order orchestrator

### DIFF
--- a/Packages/Sequence-Unity/Sequence/SequenceBoilerplates/Scripts/Marketplace/MarketplaceTile.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceBoilerplates/Scripts/Marketplace/MarketplaceTile.cs
@@ -145,7 +145,7 @@ namespace Sequence.Boilerplates.Marketplace
             }
             _boilerplateController.OpenCheckoutPanel(new NftCheckout(_wallet, _collectibleOrder, _collectibleSprite, 1),
                 new SequenceCheckout(_wallet, ChainDictionaries.ChainById[_collectibleOrder.order.chainId.ToString()],
-                    new[] { _collectibleOrder }, 1, _nftType,
+                    _collectibleOrder , 1, _nftType,
                     pay: new SequencePay(_wallet,
                         ChainDictionaries.ChainById[_collectibleOrder.order.chainId.ToString()],
                         checkout: new MockCheckoutWithSardineForCanada(new Checkout(_wallet,

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Marketplace/OrderOrchestrator.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Marketplace/OrderOrchestrator.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Sequence.Utils;
+using UnityEngine;
+
+namespace Sequence.Marketplace
+{
+    public class OrderOrchestrator
+    {
+        private static Dictionary<string, OrderOrchestrator> _orchestratorsByOrderId = new Dictionary<string, OrderOrchestrator>();
+
+        public bool Initialized { get; private set; }
+        public Dictionary<Order, ulong> AmountsByOrder { get; private set; }
+        private CollectibleOrder _listing;
+        private Order[] _listings;
+        private ulong _amountRequested;
+        private IMarketplaceReader _marketplaceReader;
+        private Page _page;
+        private CollectibleOrder[] _orders;
+        
+        private async Task FetchOtherListings()
+        {
+            try
+            {
+                ListCollectibleListingsReturn result =
+                    await _marketplaceReader.ListListingsForCollectible(
+                        new Address(_listing.order.collectionContractAddress), _listing.order.tokenId,
+                        new OrderFilter(null, null, new[] { _listing.order.priceCurrencyAddress }));
+                _page = result.page;
+                _listings = result.listings;
+            }
+            catch (Exception e)
+            {
+                string error =
+                    $"Error fetching other listings for collectible (contract: {_listing.order.collectionContractAddress}, tokenId: {_listing.order.tokenId}): {e.Message}";
+                Debug.LogError(error);
+                Initialized = true;
+                throw new Exception(error);
+            }
+            _listings = _listings.OrderBy(listing => listing.priceUSD).ToArray(); // Todo confirm if this comes pre-sorted by the API
+
+            ulong remaining = await SetAmountsByOrder();
+            if (remaining > 0)
+            {
+                ulong requested = _amountRequested + remaining; // We should already revert _amountRequested to the max available in SetAmountsByOrder
+                Debug.LogError($"Amount requested exceeds what is available in the marketplace for collectible (contract: {_listing.order.collectionContractAddress}, tokenId: {_listing.order.tokenId}), amount requested: {requested} available: {_amountRequested}. Setting requested amount to the available amount: {_amountRequested}");
+            }
+            
+            Initialized = true;
+        }
+
+        internal Task<ulong> SetAmount(ulong newAmount)
+        {
+            _amountRequested = newAmount;
+            return SetAmountsByOrder();
+        }
+            
+        private async Task<ulong> SetAmountsByOrder()
+        {
+            AmountsByOrder = new Dictionary<Order, ulong>();
+            ulong remaining = _amountRequested;
+            foreach (Order order in _listings)
+            {
+                ulong amount = Math.Min(remaining, ulong.Parse(order.quantityRemaining));
+                AmountsByOrder[order] = amount;
+                remaining -= amount;
+                if (remaining == 0)
+                {
+                    break;
+                }
+            }
+
+            if (remaining > 0 && _page.more)
+            {
+                await FetchMoreListings();
+                await SetAmountsByOrder();
+            }
+            
+            _amountRequested -= remaining;
+            
+            return remaining;
+        }
+
+        private async Task FetchMoreListings()
+        {
+            if (!_page.more)
+            {
+                return;
+            }
+
+            ListCollectibleListingsReturn result =
+                await _marketplaceReader.ListListingsForCollectible(
+                    new Address(_listing.order.collectionContractAddress), _listing.order.tokenId,
+                    new OrderFilter(null, null, new[] { _listing.order.priceCurrencyAddress }), _page);
+            _page = result.page;
+            _listings.AppendArray(result.listings);
+        }
+
+        private OrderOrchestrator()
+        {
+            throw new NotSupportedException($"Please use {nameof(GetOrchestrator)} to create an instance of {nameof(OrderOrchestrator)}");
+        }
+
+        public static OrderOrchestrator GetOrchestrator(CollectibleOrder listing, ulong initialAmount, IMarketplaceReader marketplaceReader = null)
+        {
+            if (_orchestratorsByOrderId.TryGetValue(listing.order.orderId, out OrderOrchestrator orchestrator))
+            {
+                return orchestrator;
+            }
+            else
+            {
+                _orchestratorsByOrderId[listing.order.orderId] = new OrderOrchestrator(listing, initialAmount, marketplaceReader);
+                return _orchestratorsByOrderId[listing.order.orderId];
+            }
+        }
+        
+        private OrderOrchestrator(CollectibleOrder listing, ulong initialAmount, IMarketplaceReader marketplaceReader = null)
+        {
+            _listing = listing;
+            _amountRequested = initialAmount;
+            _marketplaceReader = marketplaceReader;
+            if (_marketplaceReader == null)
+            {
+                _marketplaceReader = new MarketplaceReader(ChainDictionaries.ChainById[listing.order.chainId.ToString()]);
+            }
+            FetchOtherListings().ConfigureAwait(false);
+        }
+
+        public CollectibleOrder[] GetOrders()
+        {
+            int expectedLength = AmountsByOrder.Keys.Count;
+            if (_orders != null && _orders.Length == expectedLength)
+            {
+                return _orders;
+            }
+            
+            CollectibleOrder[] orders = new CollectibleOrder[expectedLength];
+            int i = 0;
+            foreach (var order in AmountsByOrder.Keys)
+            {
+                orders[i] = new CollectibleOrder(_listing.metadata, order);
+                i++;
+            }
+
+            _orders = orders;
+
+            return orders;
+        }
+    }
+}

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Marketplace/OrderOrchestrator.cs.meta
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Marketplace/OrderOrchestrator.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4fa67fff288944c186d56926bdaa7f3a
+timeCreated: 1742824607


### PR DESCRIPTION
Move order orchestration logic (requesting additional orders and allocating amounts to them until we can fulfill user's request) into its own class 'OrderOrchestrator' and use it as a dependency for both NftCheckout and SequenceCheckout. This fixes a bug where SequenceCheckout wouldn't request additional orders as the amount requested grew beyond the present order's availability

### Version Increment
Please ensure you have incremented the package version in the package.json as necessary.
- [ ] I have incremented the package.json according to [semantic versioning](https://docs.unity3d.com/Manual/upm-semver.html)
- [x] No version increment is needed; this portion of SDK is in Beta where we do not follow semantic versioning

### Docs Checklist
Please ensure you have addressed documentation updates if needed as part of this PR:
- [ ] I have created a separate PR on the sequence docs repository for documentation updates: [Link to docs PR](https://github.com/0xsequence/docs/pulls)
- [x] No documentation update is needed for this change.
