### PR TITLE
added Android to config's header string

### DIFF
--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Config/SequenceConfig.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Config/SequenceConfig.cs
@@ -10,7 +10,7 @@ namespace Sequence.Config
     [CreateAssetMenu(fileName = "SequenceConfig", menuName = "Sequence/SequenceConfig", order = 1)]
     public class SequenceConfig : ScriptableObject
     {
-        [Header("Social Sign In Configuration - Standalone & Web Platforms")]
+        [Header("Social Sign In Configuration - Standalone, Android & Web Platforms")]
         public string UrlScheme;
         public string GoogleClientId;
         public string DiscordClientId;


### PR DESCRIPTION
Partner was unsure if their Android config values belong to this section or not.

### Version Increment
Please ensure you have incremented the package version in the package.json as necessary.
- [ ] I have incremented the package.json according to [semantic versioning](https://docs.unity3d.com/Manual/upm-semver.html)
- [x] No version increment is needed; the change does not impact SDK or Sample code/assets

### Docs Checklist
Please ensure you have addressed documentation updates if needed as part of this PR:
- [ ] I have created a separate PR on the sequence docs repository for documentation updates: [Link to docs PR](https://github.com/0xsequence/docs/pulls)
- [x] No documentation update is needed for this change.
