### PR TITLE
When federating an account, set the new variable Account.wallet to be…

### DIFF
--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/Account.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/DataTypes/ReturnTypes/Account.cs
@@ -1,7 +1,9 @@
+using System;
 using UnityEngine.Scripting;
 
 namespace Sequence.EmbeddedWallet 
 {
+    [Serializable]
     [Preserve]
     public class Account
     {
@@ -9,6 +11,7 @@ namespace Sequence.EmbeddedWallet
         public string id;
         public IdentityType identityType;
         public string issuer;
+        public Address wallet; // This is not returned from the API - instead, we set it to the wallet address we are federating against when making the request
         
         [Preserve]
         public Account(string id, string type, string issuer, string email)

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/SequenceLogin.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/SequenceLogin.cs
@@ -605,8 +605,9 @@ namespace Sequence.EmbeddedWallet
             await connector.ConnectToWaaSViaGuest();
         }
 
-        private void StoreWalletSecurely(string waasWalletAddress, string email)
+        internal void StoreWalletSecurely(string waasWalletAddress, string email)
         {
+            if (!_storeSessionWallet || !SecureStorageFactory.IsSupportedPlatform()) return;
             ISecureStorage secureStorage = SecureStorageFactory.CreateSecureStorage();
             byte[] privateKeyBytes = new byte[32];
             _sessionWallet.privKey.WriteToSpan(privateKeyBytes);
@@ -620,6 +621,7 @@ namespace Sequence.EmbeddedWallet
             {
                 IntentResponseAccountFederated federateAccountResponse = await _intentSender.SendIntent<IntentResponseAccountFederated, IntentDataFederateAccount>(federateAccount, IntentType.FederateAccount);
                 Account account = federateAccountResponse.account;
+                account.wallet = new Address(federateAccount.wallet);
                 string responseEmail = account.email;
                 if (responseEmail != email.ToLower())
                 {

--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/SequenceWallet.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/SequenceWallet.cs
@@ -36,6 +36,16 @@ namespace Sequence.EmbeddedWallet
             SessionId = sessionId;
             _builderApiKey = SequenceConfig.GetConfig(SequenceService.WaaS).BuilderAPIKey;
             _email = email;
+            
+            OnAccountFederated += account =>
+            {
+                if (String.Equals(account.wallet, address, StringComparison.CurrentCultureIgnoreCase))
+                {
+                    _email = account.email;
+
+                    SequenceLogin.GetInstance().StoreWalletSecurely(_address, _email);
+                }
+            };
         }
 
         public Address GetWalletAddress()

--- a/Packages/Sequence-Unity/package.json
+++ b/Packages/Sequence-Unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz.0xsequence.waas-unity",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "displayName": "Sequence Embedded Wallet SDK",
   "description": "A Unity SDK for Sequence APIs",
   "unity": "2021.3",


### PR DESCRIPTION
… the target wallet address. Then, when federation success event is emitted, we update the email address associated with the wallet and save this to secure storage (if enabled and supported on the target platform). This allows us to get the user's email after federating the account and to get it in subsequent sessions that are recovered

@andygruening this should address this issue experienced by TapNation https://github.com/0xsequence/issue-tracker/issues/4761

### Version Increment
Please ensure you have incremented the package version in the package.json as necessary.
- [x] I have incremented the package.json according to [semantic versioning](https://docs.unity3d.com/Manual/upm-semver.html)
- [ ] No version increment is needed; the change does not impact SDK or Sample code/assets

### Docs Checklist
Please ensure you have addressed documentation updates if needed as part of this PR:
- [ ] I have created a separate PR on the sequence docs repository for documentation updates: [Link to docs PR](https://github.com/0xsequence/docs/pulls)
- [x] No documentation update is needed for this change.
