### PR TITLE
Attempt to re-initialize AndroidKeyBridge if uninitialized; this migh…

### DIFF
--- a/Packages/Sequence-Unity/Plugins/Android/AndroidKeyBridge.java
+++ b/Packages/Sequence-Unity/Plugins/Android/AndroidKeyBridge.java
@@ -25,15 +25,28 @@ public class AndroidKeyBridge {
 
     public void init(Context context)
     {
+        if (context == null) {
+            Log.w("AndroidKeyBridge", "Provided context is null, trying to get UnityPlayer.currentActivity");
+            try {
+                context = com.unity3d.player.UnityPlayer.currentActivity;
+            } catch (Exception e) {
+                Log.e("AndroidKeyBridge", "Failed to get UnityPlayer.currentActivity", e);
+            }
+        }
+    
+        if (context == null) {
+            Log.e("AndroidKeyBridge", "Context is still null, cannot initialize AndroidKeyBridge");
+            return;
+        }
+    
         this.context = context;
 
-        if (masterKey == null) {
+        if (masterKey == null || sharedPreferences == null) {
 
             try {
             masterKey = new MasterKey.Builder(context)
                     .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
                     .build();
-
             sharedPreferences = EncryptedSharedPreferences.create(
                     context,
                     "secret_shared_prefs",
@@ -42,9 +55,9 @@ public class AndroidKeyBridge {
                     EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
                 );
             } catch (GeneralSecurityException e){
-                Log.d("Exception", e.getMessage());
+                Log.d("AndroidKeyBridge", "Encountered error when initializing AndroidKeyBridge: " + e.getMessage());
             } catch (IOException e){
-                Log.d("Exception", e.getMessage());
+                Log.d("AndroidKeyBridge", "Encountered error when initializing AndroidKeyBridge: " + e.getMessage());
             }
         }
     }
@@ -74,11 +87,17 @@ public class AndroidKeyBridge {
 
     private void RunSaveKeychainValue(String key, String value)
     {
+        if (masterKey == null || sharedPreferences == null) {
+            init(context);
+        }
         sharedPreferences.edit().putString(key, value).apply();
     }
 
     private String RunGetKeychainValue(String key)
     {
+        if (masterKey == null || sharedPreferences == null) {
+            init(context);
+        }
         return sharedPreferences.getString(key, "");
     }
 }

--- a/Packages/Sequence-Unity/Plugins/Android/AndroidKeyBridge.java.meta
+++ b/Packages/Sequence-Unity/Plugins/Android/AndroidKeyBridge.java.meta
@@ -28,7 +28,7 @@ PluginImporter:
   - first:
       Android: Android
     second:
-      enabled: 0
+      enabled: 1
       settings:
         CPU: ARMv7
   - first:

--- a/Packages/Sequence-Unity/package.json
+++ b/Packages/Sequence-Unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz.0xsequence.waas-unity",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "displayName": "Sequence Embedded Wallet SDK",
   "description": "A Unity SDK for Sequence APIs",
   "unity": "2021.3",


### PR DESCRIPTION
…t happen if we are given a null context for example, in this case, as it is the most common, we will also attempt to fetch the context. Finally, improved logging so we have more visibility into errors.

### Version Increment
Please ensure you have incremented the package version in the package.json as necessary.
- [x] I have incremented the package.json according to [semantic versioning](https://docs.unity3d.com/Manual/upm-semver.html)
- [ ] No version increment is needed; the change does not impact SDK or Sample code/assets

### Docs Checklist
Please ensure you have addressed documentation updates if needed as part of this PR:
- [ ] I have created a separate PR on the sequence docs repository for documentation updates: [Link to docs PR](https://github.com/0xsequence/docs/pulls)
- [x] No documentation update is needed for this change.
