### PR TITLE
Mark Page.page as deprecated as this field is no longer used

### DIFF
--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Indexer/DataTypes/Page.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Indexer/DataTypes/Page.cs
@@ -1,8 +1,11 @@
+using System;
+
 namespace Sequence
 {
     [System.Serializable]
     public class Page
     {
+        [Obsolete("Page number is now deprecated. Instead, simply provide the page you are given to fetch the next page.")]
         public int page;
         public string column;
         public object before;

--- a/Packages/Sequence-Unity/package.json
+++ b/Packages/Sequence-Unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz.0xsequence.waas-unity",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "displayName": "Sequence Embedded Wallet SDK",
   "description": "A Unity SDK for Sequence APIs",
   "unity": "2021.3",


### PR DESCRIPTION
To work with our pagination, you simply include the previous Page object as opposed to requesting a specific page number. The page number 'page' variable is being deprecated to make this more clear to users

### Version Increment
Please ensure you have incremented the package version in the package.json as necessary.
- [x] I have incremented the package.json according to [semantic versioning](https://docs.unity3d.com/Manual/upm-semver.html)
- [ ] No version increment is needed; the change does not impact SDK or Sample code/assets

### Docs Checklist
Please ensure you have addressed documentation updates if needed as part of this PR:
- [ ] I have created a separate PR on the sequence docs repository for documentation updates: [Link to docs PR](https://github.com/0xsequence/docs/pulls)
- [x] No documentation update is needed for this change. - working with our pagination is already documented in our Unity docs
