### PR TITLE
Checking if the cached email value is empty to avoid having the 'login_hint' inside the sign-in url

### DIFF
--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Authentication/OpenIdAuthenticator.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Authentication/OpenIdAuthenticator.cs
@@ -231,7 +231,8 @@ namespace Sequence.Authentication
 
             string url =
                 $"{baseUrl}?response_type=code+id_token&client_id={clientId}&redirect_uri={_redirectUrl}&scope=openid+email&state={state}/";
-            if (PlayerPrefs.HasKey(LoginEmail))
+            
+            if (PlayerPrefs.HasKey(LoginEmail) && !string.IsNullOrEmpty(PlayerPrefs.GetString(LoginEmail)))
             {
                 url = url.RemoveTrailingSlash() + $"&login_hint={PlayerPrefs.GetString(LoginEmail)}".AppendTrailingSlashIfNeeded();
                 url = url.Replace(" ", "");

--- a/Packages/Sequence-Unity/package.json
+++ b/Packages/Sequence-Unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz.0xsequence.waas-unity",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "displayName": "Sequence Embedded Wallet SDK",
   "description": "A Unity SDK for Sequence APIs",
   "unity": "2021.3",


### PR DESCRIPTION
How to test the failure case:
- Add the following line of code before checking the PlayerPrefs.HasKey() inside GenerateSignInUrl(). This will ensure a cached email exists, but it's empty
`PlayerPrefs.SetString(LoginEmail, string.Empty);`
- Run an Android build

Expected result during this test:
- The login hint is included like so:
`&login_hint=/` which will open the google sign-in page as a 'Manage Google Accounts' page

### Version Increment
Please ensure you have incremented the package version in the package.json as necessary.
- [x] I have incremented the package.json according to [semantic versioning](https://docs.unity3d.com/Manual/upm-semver.html)
- [ ] No version increment is needed; the change does not impact SDK or Sample code/assets

### Docs Checklist
Please ensure you have addressed documentation updates if needed as part of this PR:
- [ ] I have created a separate PR on the sequence docs repository for documentation updates: [Link to docs PR](https://github.com/0xsequence/docs/pulls)
- [x] No documentation update is needed for this change.
