### PR TITLE
Fixed null reference exception for SetConnectedWalletAddress inside SequenceLogin.GetInstance()

### DIFF
--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/SequenceLogin.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/EmbeddedWallet/SequenceLogin.cs
@@ -96,7 +96,11 @@ namespace Sequence.EmbeddedWallet
             _connector = connector;
             
             _automaticallyFederateAccountsWhenPossible = automaticallyFederateAccountsWhenPossible;
-            SetConnectedWalletAddress(connectedWalletAddress);
+
+            if (connectedWalletAddress != null)
+            {
+                SetConnectedWalletAddress(connectedWalletAddress);
+            }
             
             bool storeSessionWallet = SequenceConfig.GetConfig(SequenceService.WaaS).StoreSessionKey() && SecureStorageFactory.IsSupportedPlatform() && connectedWalletAddress == null;
             if (storeSessionWallet)

--- a/Packages/Sequence-Unity/package.json
+++ b/Packages/Sequence-Unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz.0xsequence.waas-unity",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "displayName": "Sequence Embedded Wallet SDK",
   "description": "A Unity SDK for Sequence APIs",
   "unity": "2021.3",


### PR DESCRIPTION
Fix for an issue mentioned by My Lovely Planet, a null exception when using SequenceLogin.GetInstance()

### Version Increment
Please ensure you have incremented the package version in the package.json as necessary.
- [x] I have incremented the package.json according to [semantic versioning](https://docs.unity3d.com/Manual/upm-semver.html)
- [ ] No version increment is needed; the change does not impact SDK or Sample code/assets

### Docs Checklist
Please ensure you have addressed documentation updates if needed as part of this PR:
- [ ] I have created a separate PR on the sequence docs repository for documentation updates: [Link to docs PR](https://github.com/0xsequence/docs/pulls)
- [x] No documentation update is needed for this change.
