### PR TITLE
Package version reader searches for the Packages/xyz.sequence../ directory

### DIFF
--- a/Packages/Sequence-Unity/Sequence/SequenceSDK/Config/PackageVersionReader.cs
+++ b/Packages/Sequence-Unity/Sequence/SequenceSDK/Config/PackageVersionReader.cs
@@ -19,12 +19,15 @@ namespace Sequence.Config
             return ExtractVersionFromJson(json);
         }
 
+
         private static string FindPackageJsonPath()
         {
-            string packagesPath = "Packages/Sequence-Unity/package.json";
-            if (File.Exists(packagesPath))
+            if (CheckDirectories(new[] {
+                    "Packages/Sequence-Unity/package.json",
+                    "Packages/xyz.0xsequence.waas-unity/package.json"
+                }, out var availableFile))
             {
-                return packagesPath;
+                return availableFile;
             }
 
             string[] directories = Directory.GetDirectories("Library/PackageCache/", "xyz.0xsequence.waas-unity*", SearchOption.TopDirectoryOnly);
@@ -40,6 +43,21 @@ namespace Sequence.Config
             }
 
             return null;
+        }
+
+        private static bool CheckDirectories(string[] files, out string availableFile)
+        {
+            foreach (var file in files)
+            {
+                if (File.Exists(file))
+                {
+                    availableFile = file;
+                    return true;
+                }   
+            }
+
+            availableFile = null;
+            return false;
         }
 
         private static string ExtractVersionFromJson(string json)

--- a/Packages/Sequence-Unity/package.json
+++ b/Packages/Sequence-Unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz.0xsequence.waas-unity",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "displayName": "Sequence Embedded Wallet SDK",
   "description": "A Unity SDK for Sequence APIs",
   "unity": "2021.3",


### PR DESCRIPTION
Releases from the Unity Asset Store and .unitypackages cannot be used when the package is not stored inside the Library/Packages/ directory.

### Version Increment
Please ensure you have incremented the package version in the package.json as necessary.
- [x] I have incremented the package.json according to [semantic versioning](https://docs.unity3d.com/Manual/upm-semver.html)
- [ ] No version increment is needed; the change does not impact SDK or Sample code/assets

### Docs Checklist
Please ensure you have addressed documentation updates if needed as part of this PR:
- [ ] I have created a separate PR on the sequence docs repository for documentation updates: [Link to docs PR](https://github.com/0xsequence/docs/pulls)
- [x] No documentation update is needed for this change.
