### PR TITLE
chore: update company name references

### DIFF
--- a/Packages/Sequence-Unity/LICENSE
+++ b/Packages/Sequence-Unity/LICENSE
@@ -1,4 +1,4 @@
-   Copyright (c) 2017-present Sequence Platforms ULC Inc.
+   Copyright (c) 2017-present Sequence Platforms ULC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Packages/Sequence-Unity/LICENSE
+++ b/Packages/Sequence-Unity/LICENSE
@@ -1,4 +1,4 @@
-   Copyright (c) 2017-present Horizon Blockchain Games Inc.
+   Copyright (c) 2017-present Sequence Platforms ULC Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Automated cleanup of legacy company name references:

- "Horizon Blockchain Games" → "Sequence Platforms ULC"
- "Sequence Platforms Inc." → "Sequence Platforms ULC"
- "Horizon" → "Sequence"

Scope: README / LICENSE / package.json files (excluding vendor/).